### PR TITLE
XIVY-15096 add main content

### DIFF
--- a/packages/cms-editor/src/CmsEditor.css
+++ b/packages/cms-editor/src/CmsEditor.css
@@ -2,3 +2,7 @@
 
 @import '@axonivy/ui-icons/src-gen/ivy-icons.css' layer(icons);
 @import '@axonivy/ui-components/lib/components.css';
+
+.cms-editor-main-panel {
+  background-color: var(--N75);
+}

--- a/packages/cms-editor/src/CmsEditor.tsx
+++ b/packages/cms-editor/src/CmsEditor.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
 import './CmsEditor.css';
 import { AppProvider } from './context/AppContext';
+import { MainContent } from './main/MainContent';
 import { MainToolbar } from './main/MainToolbar';
 import { useClient } from './protocol/ClientContextProvider';
 import { genQueryKey } from './query/query-client';
@@ -16,6 +17,7 @@ function CmsEditor(props: EditorProps) {
   useEffect(() => {
     setContext(props.context);
   }, [props]);
+  const [selectedContentObject, setSelectedContentObject] = useState<number>();
 
   const client = useClient();
 
@@ -44,19 +46,19 @@ function CmsEditor(props: EditorProps) {
   }
 
   return (
-    <AppProvider value={{ detail, setDetail }}>
+    <AppProvider value={{ contentObjects: data.data, selectedContentObject, setSelectedContentObject, detail, setDetail }}>
       <ResizablePanelGroup direction='horizontal'>
-        <ResizablePanel defaultSize={75} minSize={50}>
+        <ResizablePanel defaultSize={75} minSize={50} className='cms-editor-main-panel'>
           <Flex direction='column'>
             <MainToolbar title='CMS Editor main title' />
-            <div className='cms-editor-content'>{JSON.stringify(data.data)}</div>
+            <MainContent />
           </Flex>
         </ResizablePanel>
         {detail && (
           <>
             <ResizableHandle />
-            <ResizablePanel defaultSize={25} minSize={10}>
-              <Flex direction='column' className='cms-editor-detail-panel'>
+            <ResizablePanel defaultSize={25} minSize={10} className='cms-editor-detail-panel'>
+              <Flex direction='column'>
                 <SidebarHeader icon={IvyIcons.PenEdit} title='CMS Editor detail title' />
                 <div>detail</div>
               </Flex>

--- a/packages/cms-editor/src/context/AppContext.tsx
+++ b/packages/cms-editor/src/context/AppContext.tsx
@@ -1,11 +1,18 @@
+import type { ContentObject } from '@axonivy/cms-editor-protocol';
 import { createContext, useContext } from 'react';
 
 type AppContext = {
+  contentObjects: Array<ContentObject>;
+  selectedContentObject?: number;
+  setSelectedContentObject: (index?: number) => void;
   detail: boolean;
   setDetail: (visible: boolean) => void;
 };
 
 const appContext = createContext<AppContext>({
+  contentObjects: [],
+  selectedContentObject: undefined,
+  setSelectedContentObject: () => {},
   detail: true,
   setDetail: () => {}
 });

--- a/packages/cms-editor/src/main/MainContent.css
+++ b/packages/cms-editor/src/main/MainContent.css
@@ -1,0 +1,3 @@
+.cms-editor-main-content {
+  padding: var(--size-3);
+}

--- a/packages/cms-editor/src/main/MainContent.tsx
+++ b/packages/cms-editor/src/main/MainContent.tsx
@@ -1,0 +1,74 @@
+import { type ContentObject } from '@axonivy/cms-editor-protocol';
+import {
+  BasicField,
+  Flex,
+  SelectRow,
+  selectRow,
+  SortableHeader,
+  Table,
+  TableBody,
+  TableCell,
+  TableResizableHeader,
+  useTableKeyHandler,
+  useTableSelect,
+  useTableSort
+} from '@axonivy/ui-components';
+import { flexRender, getCoreRowModel, useReactTable, type ColumnDef } from '@tanstack/react-table';
+import { useAppContext } from '../context/AppContext';
+import './MainContent.css';
+
+export const MainContent = () => {
+  const { contentObjects, setSelectedContentObject, detail, setDetail } = useAppContext();
+
+  const selection = useTableSelect<ContentObject>({
+    onSelect: selectedRows => {
+      const selectedRowId = Object.keys(selectedRows).find(key => selectedRows[key]);
+      const selectedContentObject = table.getRowModel().flatRows.find(row => row.id === selectedRowId)?.index;
+      setSelectedContentObject(selectedContentObject);
+    }
+  });
+
+  const sort = useTableSort();
+
+  const columns: Array<ColumnDef<ContentObject, string>> = [
+    {
+      accessorKey: 'uri',
+      header: ({ column }) => <SortableHeader column={column} name='URI' />,
+      cell: cell => <span>{cell.getValue()}</span>,
+      minSize: 50
+    }
+  ];
+
+  const table = useReactTable({
+    ...selection.options,
+    ...sort.options,
+    data: contentObjects,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    state: {
+      ...selection.tableState,
+      ...sort.tableState
+    }
+  });
+
+  const { handleKeyDown } = useTableKeyHandler({ table, data: contentObjects });
+
+  return (
+    <Flex direction='column' gap={4} onClick={() => selectRow(table)} className='cms-editor-main-content'>
+      <BasicField label='Content Objects' onClick={event => event.stopPropagation()}>
+        <Table onKeyDown={event => handleKeyDown(event, () => setDetail(!detail))}>
+          <TableResizableHeader headerGroups={table.getHeaderGroups()} onClick={() => selectRow(table)} />
+          <TableBody>
+            {table.getRowModel().rows.map(row => (
+              <SelectRow key={row.id} row={row}>
+                {row.getVisibleCells().map(cell => (
+                  <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+                ))}
+              </SelectRow>
+            ))}
+          </TableBody>
+        </Table>
+      </BasicField>
+    </Flex>
+  );
+};

--- a/playwright/tests/integration/cms.spec.ts
+++ b/playwright/tests/integration/cms.spec.ts
@@ -8,5 +8,5 @@ test.beforeEach(async ({ page }) => {
 });
 
 test('load data', async () => {
-  await expect(editor.page.locator('.cms-editor-content')).toHaveText('[{"uri":"/content","values":{"en":"object"}}]');
+  await expect(editor.main.table.row(0).column(0).locator).toHaveText('/content');
 });

--- a/playwright/tests/integration/mock/editor.spec.ts
+++ b/playwright/tests/integration/mock/editor.spec.ts
@@ -13,8 +13,8 @@ test('title', async ({ page }) => {
 
 test('toggle detail', async () => {
   await expect(editor.detail).toBeVisible();
-  await editor.mainToolbar.detailToggle.click();
+  await editor.main.toolbar.detailToggle.click();
   await expect(editor.detail).toBeHidden();
-  await editor.mainToolbar.detailToggle.click();
+  await editor.main.toolbar.detailToggle.click();
   await expect(editor.detail).toBeVisible();
 });

--- a/playwright/tests/integration/mock/table.spec.ts
+++ b/playwright/tests/integration/mock/table.spec.ts
@@ -1,0 +1,32 @@
+import test, { expect } from '@playwright/test';
+import { CmsEditor } from '../../pageobjects/CmsEditor';
+
+let editor: CmsEditor;
+
+test.beforeEach(async ({ page }) => {
+  editor = await CmsEditor.openMock(page);
+});
+
+test.describe('table keyboard support', () => {
+  test('move selection via arrowKey', async () => {
+    await editor.main.table.expectToHaveNoSelection();
+    await editor.main.table.locator.focus();
+    await editor.page.keyboard.press('ArrowDown');
+    await editor.page.keyboard.press('ArrowDown');
+    await editor.main.table.row(1).expectToBeSelected();
+
+    await editor.page.keyboard.press('ArrowUp');
+    await editor.page.keyboard.press('ArrowUp');
+    await editor.page.keyboard.press('ArrowUp');
+    await editor.main.table.row(106).expectToBeSelected();
+  });
+
+  test('toggle detail via enter', async () => {
+    await editor.main.table.row(0).locator.click();
+    await expect(editor.detail).toBeVisible();
+    await editor.page.keyboard.press('Enter');
+    await expect(editor.detail).toBeHidden();
+    await editor.page.keyboard.press('Enter');
+    await expect(editor.detail).toBeVisible();
+  });
+});

--- a/playwright/tests/pageobjects/CmsEditor.ts
+++ b/playwright/tests/pageobjects/CmsEditor.ts
@@ -1,5 +1,5 @@
 import { expect, type Locator, type Page } from '@playwright/test';
-import { MainToolbar } from './MainToolbar';
+import { MainPanel } from './main/MainPanel';
 
 export const server = process.env.BASE_URL ?? 'http://localhost:8081';
 export const user = 'Developer';
@@ -9,13 +9,13 @@ const pmv = 'cms-test-project';
 
 export class CmsEditor {
   readonly page: Page;
-  readonly mainToolbar: MainToolbar;
+  readonly main: MainPanel;
   readonly detail: Locator;
 
   constructor(page: Page) {
     this.page = page;
-    this.mainToolbar = new MainToolbar(page);
-    this.detail = page.locator('.cms-editor-detail-panel');
+    this.main = new MainPanel(this.page);
+    this.detail = this.page.locator('.cms-editor-detail-panel');
   }
 
   static async openCms(page: Page, options?: { readonly?: boolean }) {

--- a/playwright/tests/pageobjects/main/MainPanel.ts
+++ b/playwright/tests/pageobjects/main/MainPanel.ts
@@ -1,0 +1,15 @@
+import type { Locator, Page } from '@playwright/test';
+import { MainToolbar } from './MainToolbar';
+import { Table } from './Table';
+
+export class MainPanel {
+  readonly locator: Locator;
+  readonly toolbar: MainToolbar;
+  readonly table: Table;
+
+  constructor(page: Page) {
+    this.locator = page.locator('.cms-editor-main-panel');
+    this.toolbar = new MainToolbar(this.locator);
+    this.table = new Table(this.locator);
+  }
+}

--- a/playwright/tests/pageobjects/main/MainToolbar.ts
+++ b/playwright/tests/pageobjects/main/MainToolbar.ts
@@ -1,11 +1,11 @@
-import type { Locator, Page } from '@playwright/test';
+import type { Locator } from '@playwright/test';
 
 export class MainToolbar {
   readonly locator: Locator;
   readonly detailToggle: Locator;
 
-  constructor(page: Page) {
-    this.locator = page.locator('.cms-editor-main-toolbar');
+  constructor(parent: Locator) {
+    this.locator = parent.locator('.cms-editor-main-toolbar');
     this.detailToggle = this.locator.getByRole('button', { name: 'Details toggle' });
   }
 }

--- a/playwright/tests/pageobjects/main/Table.ts
+++ b/playwright/tests/pageobjects/main/Table.ts
@@ -1,0 +1,51 @@
+import { expect, type Locator } from '@playwright/test';
+
+export class Table {
+  readonly locator: Locator;
+  readonly rows: Locator;
+
+  constructor(parent: Locator) {
+    this.locator = parent.locator('table');
+    this.rows = this.locator.locator('tbody tr');
+  }
+
+  row(index: number) {
+    return new Row(this.rows, index);
+  }
+
+  async expectToHaveNoSelection() {
+    for (let i = 0; i < (await this.rows.count()); i++) {
+      await this.row(i).expectToBeUnselected();
+    }
+  }
+}
+
+export class Row {
+  readonly locator: Locator;
+
+  constructor(rows: Locator, index: number) {
+    this.locator = rows.nth(index);
+  }
+
+  column(index: number) {
+    return new Cell(this.locator, index);
+  }
+
+  async expectToBeSelected() {
+    await expect(this.locator).toHaveAttribute('data-state', 'selected');
+  }
+
+  async expectToBeUnselected() {
+    await expect(this.locator).toHaveAttribute('data-state', 'unselected');
+  }
+}
+
+export class Cell {
+  readonly locator: Locator;
+  readonly content: Locator;
+
+  constructor(row: Locator, index: number) {
+    this.locator = row.locator('td').nth(index);
+    this.content = this.locator.locator('span');
+  }
+}


### PR DESCRIPTION
Add a table displaying the content objects to the main panel.
Includes:
- Selectable rows
- Sorting by column
- Table keyboard support
