### PR TITLE
XIVY-15943 always have default language

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "@types/react": "^19.0.7",
         "@types/react-dom": "^19.0.3",
         "@vitejs/plugin-react": "^4.3.4",
-        "vite": "^6.2.4"
+        "vite": "^6.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/packages/cms-editor/src/CmsEditor.test.ts
+++ b/packages/cms-editor/src/CmsEditor.test.ts
@@ -1,8 +1,5 @@
-import type { Client, CmsEditorDataContext, ContentObject } from '@axonivy/cms-editor-protocol';
-import { waitFor } from '@testing-library/react';
-import i18next from 'i18next';
-import { toolbarTitles, useLanguage } from './CmsEditor';
-import { customRenderHook } from './context/test-utils/test-utils';
+import type { ContentObject } from '@axonivy/cms-editor-protocol';
+import { toolbarTitles } from './CmsEditor';
 
 test('toolbarTitles', () => {
   expect(toolbarTitles('pmv-name')).toEqual({ mainTitle: 'CMS - pmv-name', detailTitle: 'CMS - pmv-name' });
@@ -15,40 +12,3 @@ test('toolbarTitles', () => {
     detailTitle: 'CMS - pmv-name - content-object-uri'
   });
 });
-
-test('useLanguage', async () => {
-  let result = renderLanguageHook('de', []).result;
-  expect(result.current.defaultLanguageTag).toEqual('de');
-  expect(result.current.languageDisplayName.resolvedOptions().locale).toEqual('de');
-
-  result = renderLanguageHook('de', ['ja', 'en']).result;
-  await waitFor(() => {
-    expect(result.current.defaultLanguageTag).toEqual('en');
-  });
-  expect(result.current.languageDisplayName.resolvedOptions().locale).toEqual('de');
-
-  result = renderLanguageHook('de', ['ja', 'fr']).result;
-  await waitFor(() => {
-    expect(result.current.defaultLanguageTag).toEqual('ja');
-  });
-  expect(result.current.languageDisplayName.resolvedOptions().locale).toEqual('de');
-});
-
-const renderLanguageHook = (clientLanguage: string, locales: Array<string>) => {
-  i18next.language = clientLanguage;
-  return customRenderHook(() => useLanguage({} as CmsEditorDataContext), {
-    wrapperProps: { clientContext: { client: new TestClient(locales) } }
-  });
-};
-
-class TestClient implements Partial<Client> {
-  private readonly locales: Array<string>;
-
-  constructor(locales: Array<string>) {
-    this.locales = locales;
-  }
-
-  meta(): Promise<Array<string>> {
-    return Promise.resolve(this.locales);
-  }
-}

--- a/packages/cms-editor/src/CmsEditor.test.ts
+++ b/packages/cms-editor/src/CmsEditor.test.ts
@@ -1,5 +1,8 @@
-import type { ContentObject } from '@axonivy/cms-editor-protocol';
-import { toolbarTitles } from './CmsEditor';
+import type { Client, CmsEditorDataContext, ContentObject } from '@axonivy/cms-editor-protocol';
+import { waitFor } from '@testing-library/react';
+import i18next from 'i18next';
+import { toolbarTitles, useLanguage } from './CmsEditor';
+import { customRenderHook } from './context/test-utils/test-utils';
 
 test('toolbarTitles', () => {
   expect(toolbarTitles('pmv-name')).toEqual({ mainTitle: 'CMS - pmv-name', detailTitle: 'CMS - pmv-name' });
@@ -12,3 +15,40 @@ test('toolbarTitles', () => {
     detailTitle: 'CMS - pmv-name - content-object-uri'
   });
 });
+
+test('useLanguage', async () => {
+  let result = renderLanguageHook('de', []).result;
+  expect(result.current.defaultLanguageTag).toEqual('de');
+  expect(result.current.languageDisplayName.resolvedOptions().locale).toEqual('de');
+
+  result = renderLanguageHook('de', ['ja', 'en']).result;
+  await waitFor(() => {
+    expect(result.current.defaultLanguageTag).toEqual('en');
+  });
+  expect(result.current.languageDisplayName.resolvedOptions().locale).toEqual('de');
+
+  result = renderLanguageHook('de', ['ja', 'fr']).result;
+  await waitFor(() => {
+    expect(result.current.defaultLanguageTag).toEqual('ja');
+  });
+  expect(result.current.languageDisplayName.resolvedOptions().locale).toEqual('de');
+});
+
+const renderLanguageHook = (clientLanguage: string, locales: Array<string>) => {
+  i18next.language = clientLanguage;
+  return customRenderHook(() => useLanguage({} as CmsEditorDataContext), {
+    wrapperProps: { clientContext: { client: new TestClient(locales) } }
+  });
+};
+
+class TestClient implements Partial<Client> {
+  private readonly locales: Array<string>;
+
+  constructor(locales: Array<string>) {
+    this.locales = locales;
+  }
+
+  meta(): Promise<Array<string>> {
+    return Promise.resolve(this.locales);
+  }
+}

--- a/packages/cms-editor/src/CmsEditor.tsx
+++ b/packages/cms-editor/src/CmsEditor.tsx
@@ -1,9 +1,8 @@
-import type { CmsEditorDataContext, ContentObject, EditorProps } from '@axonivy/cms-editor-protocol';
+import type { ContentObject, EditorProps } from '@axonivy/cms-editor-protocol';
 import { Flex, PanelMessage, ResizableHandle, ResizablePanel, ResizablePanelGroup, Spinner, useHotkeys } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { useQuery } from '@tanstack/react-query';
-import i18next from 'i18next';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import './CmsEditor.css';
 import { AppProvider } from './context/AppContext';
@@ -13,8 +12,8 @@ import { MainContent } from './main/MainContent';
 import { MainToolbar } from './main/MainToolbar';
 import { useClient } from './protocol/ClientContextProvider';
 import { useAction } from './protocol/use-action';
-import { useMeta } from './protocol/use-meta';
 import { useQueryKeys } from './query/query-client';
+import { useLanguage } from './use-language';
 import { useKnownHotkeys } from './utils/hotkeys';
 
 function CmsEditor(props: EditorProps) {
@@ -104,24 +103,4 @@ export const toolbarTitles = (pmv: string, contentObject?: ContentObject) => {
     detailTitle += ` - ${contentObject.uri.substring(lastSlashIndex + 1)}`;
   }
   return { mainTitle, detailTitle };
-};
-
-export const useLanguage = (context: CmsEditorDataContext) => {
-  const clientLanguageTag = i18next.language;
-  const languageDisplayName = useMemo(() => new Intl.DisplayNames([clientLanguageTag], { type: 'language' }), [clientLanguageTag]);
-
-  const locales = useMeta('meta/locales', context, []);
-  const defaultLanguageTag = useMemo(() => defaultLanguage(locales.data, clientLanguageTag), [locales.data, clientLanguageTag]);
-
-  return { defaultLanguageTag, languageDisplayName };
-};
-
-const defaultLanguage = (locales: Array<string>, clientLanguageTag: string) => {
-  if (locales.includes(clientLanguageTag) || locales.length === 0) {
-    return clientLanguageTag;
-  }
-  if (locales.includes('en')) {
-    return 'en';
-  }
-  return locales[0];
 };

--- a/packages/cms-editor/src/context/AppContext.tsx
+++ b/packages/cms-editor/src/context/AppContext.tsx
@@ -8,6 +8,8 @@ type AppContext = {
   setSelectedContentObject: (index?: number) => void;
   detail: boolean;
   setDetail: (visible: boolean) => void;
+  defaultLanguageTag: string;
+  languageDisplayName: Intl.DisplayNames;
 };
 
 const appContext = createContext<AppContext>({
@@ -16,7 +18,9 @@ const appContext = createContext<AppContext>({
   selectedContentObject: undefined,
   setSelectedContentObject: () => {},
   detail: true,
-  setDetail: () => {}
+  setDetail: () => {},
+  defaultLanguageTag: '',
+  languageDisplayName: new Intl.DisplayNames(undefined, { type: 'language' })
 });
 
 export const AppProvider = appContext.Provider;

--- a/packages/cms-editor/src/context/test-utils/test-utils.tsx
+++ b/packages/cms-editor/src/context/test-utils/test-utils.tsx
@@ -1,0 +1,32 @@
+import type { Client } from '@axonivy/cms-editor-protocol';
+import { QueryClient } from '@tanstack/react-query';
+import { renderHook, type RenderHookOptions } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { ClientContextProvider } from '../../protocol/ClientContextProvider';
+import { QueryProvider } from '../../query/QueryProvider';
+
+type ContextHelperProps = {
+  clientContext?: {
+    client?: Partial<Client>;
+  };
+};
+
+const ContextHelper = ({ clientContext, children }: ContextHelperProps & { children: ReactNode }) => {
+  const client = (clientContext?.client ?? {}) as Client;
+
+  return (
+    <ClientContextProvider client={client}>
+      <QueryProvider client={new QueryClient()}>{children}</QueryProvider>
+    </ClientContextProvider>
+  );
+};
+
+export const customRenderHook = <Result, Props>(
+  render: (initialProps: Props) => Result,
+  options?: RenderHookOptions<Props> & { wrapperProps: ContextHelperProps }
+) => {
+  return renderHook(render, {
+    wrapper: props => <ContextHelper {...props} {...options?.wrapperProps} />,
+    ...options
+  });
+};

--- a/packages/cms-editor/src/detail/DetailContent.tsx
+++ b/packages/cms-editor/src/detail/DetailContent.tsx
@@ -6,14 +6,11 @@ import { useAppContext } from '../context/AppContext';
 import { useClient } from '../protocol/ClientContextProvider';
 import { useMeta } from '../protocol/use-meta';
 import { useQueryKeys } from '../query/query-client';
-import { useClientLanguage } from '../utils/use-client-language';
 import './DetailContent.css';
 
 export const DetailContent = () => {
   const { t } = useTranslation();
-  const { context, contentObjects, selectedContentObject } = useAppContext();
-
-  const { languageDisplayName } = useClientLanguage();
+  const { context, contentObjects, selectedContentObject, languageDisplayName } = useAppContext();
 
   const client = useClient();
   const { readKey } = useQueryKeys();

--- a/packages/cms-editor/src/main/MainContent.tsx
+++ b/packages/cms-editor/src/main/MainContent.tsx
@@ -21,15 +21,13 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppContext } from '../context/AppContext';
-import { useMeta } from '../protocol/use-meta';
 import { useKnownHotkeys } from '../utils/hotkeys';
-import { useClientLanguage } from '../utils/use-client-language';
 import './MainContent.css';
 import { MainControl } from './control/MainControl';
 
 export const MainContent = () => {
   const { t } = useTranslation();
-  const { context, contentObjects, setSelectedContentObject, detail, setDetail } = useAppContext();
+  const { contentObjects, setSelectedContentObject, detail, setDetail, defaultLanguageTag, languageDisplayName } = useAppContext();
 
   const selection = useTableSelect<ContentObject>({
     onSelect: selectedRows => {
@@ -51,22 +49,17 @@ export const MainContent = () => {
       minSize: 200,
       size: 500,
       maxSize: 1000
-    }
-  ];
-
-  const locales = useMeta('meta/locales', context, []).data;
-  const { clientLanguageTag, languageDisplayName } = useClientLanguage();
-  if (locales.includes(clientLanguageTag)) {
-    columns.push({
-      id: clientLanguageTag,
-      accessorFn: co => co.values[clientLanguageTag],
-      header: ({ column }) => <SortableHeader column={column} name={languageDisplayName.of(clientLanguageTag) ?? clientLanguageTag} />,
+    },
+    {
+      id: defaultLanguageTag,
+      accessorFn: co => co.values[defaultLanguageTag],
+      header: ({ column }) => <SortableHeader column={column} name={languageDisplayName.of(defaultLanguageTag) ?? defaultLanguageTag} />,
       cell: cell => <span>{cell.getValue()}</span>,
       minSize: 200,
       size: 500,
       maxSize: 1000
-    });
-  }
+    }
+  ];
 
   const table = useReactTable({
     ...selection.options,

--- a/packages/cms-editor/src/use-language.test.ts
+++ b/packages/cms-editor/src/use-language.test.ts
@@ -1,0 +1,42 @@
+import type { Client, CmsEditorDataContext } from '@axonivy/cms-editor-protocol';
+import { waitFor } from '@testing-library/react';
+import i18next from 'i18next';
+import { customRenderHook } from './context/test-utils/test-utils';
+import { useLanguage } from './use-language';
+
+test('useLanguage', async () => {
+  let result = renderLanguageHook('de', []).result;
+  expect(result.current.defaultLanguageTag).toEqual('de');
+  expect(result.current.languageDisplayName.resolvedOptions().locale).toEqual('de');
+
+  result = renderLanguageHook('de', ['ja', 'en']).result;
+  await waitFor(() => {
+    expect(result.current.defaultLanguageTag).toEqual('en');
+  });
+  expect(result.current.languageDisplayName.resolvedOptions().locale).toEqual('de');
+
+  result = renderLanguageHook('de', ['ja', 'fr']).result;
+  await waitFor(() => {
+    expect(result.current.defaultLanguageTag).toEqual('ja');
+  });
+  expect(result.current.languageDisplayName.resolvedOptions().locale).toEqual('de');
+});
+
+const renderLanguageHook = (clientLanguage: string, locales: Array<string>) => {
+  i18next.language = clientLanguage;
+  return customRenderHook(() => useLanguage({} as CmsEditorDataContext), {
+    wrapperProps: { clientContext: { client: new TestClient(locales) } }
+  });
+};
+
+class TestClient implements Partial<Client> {
+  private readonly locales: Array<string>;
+
+  constructor(locales: Array<string>) {
+    this.locales = locales;
+  }
+
+  meta(): Promise<Array<string>> {
+    return Promise.resolve(this.locales);
+  }
+}

--- a/packages/cms-editor/src/use-language.ts
+++ b/packages/cms-editor/src/use-language.ts
@@ -1,0 +1,24 @@
+import type { CmsEditorDataContext } from '@axonivy/cms-editor-protocol';
+import i18next from 'i18next';
+import { useMemo } from 'react';
+import { useMeta } from './protocol/use-meta';
+
+export const useLanguage = (context: CmsEditorDataContext) => {
+  const clientLanguageTag = i18next.language;
+  const languageDisplayName = useMemo(() => new Intl.DisplayNames([clientLanguageTag], { type: 'language' }), [clientLanguageTag]);
+
+  const locales = useMeta('meta/locales', context, []);
+  const defaultLanguageTag = useMemo(() => defaultLanguage(locales.data, clientLanguageTag), [locales.data, clientLanguageTag]);
+
+  return { defaultLanguageTag, languageDisplayName };
+};
+
+const defaultLanguage = (locales: Array<string>, clientLanguageTag: string) => {
+  if (locales.includes(clientLanguageTag) || locales.length === 0) {
+    return clientLanguageTag;
+  }
+  if (locales.includes('en')) {
+    return 'en';
+  }
+  return locales[0];
+};

--- a/packages/cms-editor/src/utils/use-client-language.ts
+++ b/packages/cms-editor/src/utils/use-client-language.ts
@@ -1,8 +1,0 @@
-import i18next from 'i18next';
-import { useMemo } from 'react';
-
-export const useClientLanguage = () => {
-  const clientLanguageTag = i18next.language;
-  const languageDisplayName = useMemo(() => new Intl.DisplayNames([clientLanguageTag], { type: 'language' }), [clientLanguageTag]);
-  return { clientLanguageTag, languageDisplayName };
-};

--- a/playwright/tests/integration/mock/add.spec.ts
+++ b/playwright/tests/integration/mock/add.spec.ts
@@ -22,10 +22,10 @@ test('default values', async () => {
   await expect(editor.main.add.defaultLocaleTextbox).toHaveValue('');
 });
 
-test('show field for value of client locale if it is present in the cms', async ({ page }) => {
+test('show field for value of default language', async ({ page }) => {
   editor = await CmsEditor.openMock(page, { lng: 'ja' });
   await editor.main.add.trigger.click();
-  await expect(editor.main.add.defaultLocaleLabel).toBeHidden();
+  await expect(editor.main.add.defaultLocaleLabel).toHaveText('英語');
 
   editor = await CmsEditor.openMock(page, { lng: 'en' });
   await editor.main.add.trigger.click();

--- a/playwright/tests/integration/mock/main.spec.ts
+++ b/playwright/tests/integration/mock/main.spec.ts
@@ -33,10 +33,12 @@ test.describe('table keyboard support', () => {
   });
 });
 
-test('show column for client locale if it is present in the cms', async ({ page }) => {
+test('show column for default language', async ({ page }) => {
   editor = await CmsEditor.openMock(page, { lng: 'ja' });
-  await expect(editor.main.table.headers).toHaveCount(1);
+  await expect(editor.main.table.headers).toHaveCount(2);
   await expect(editor.main.table.header(0).content).toHaveText('URI');
+  await expect(editor.main.table.header(1).content).toHaveText('英語');
+  await expect(editor.main.table.row(2).column(1).content).toHaveText('Case');
 
   editor = await CmsEditor.openMock(page, { lng: 'en' });
   await expect(editor.main.table.headers).toHaveCount(2);


### PR DESCRIPTION
1. Use the client locale if it's present in the CMS.
2. Use English if it's present in the CMS.
3. Use the first locale found in the CMS.
4. If the CMS has no locales at all, use the client locale.