### PR TITLE
XIVY-15943 validate add dialog

### DIFF
--- a/packages/cms-editor/src/components/CmsValueField.tsx
+++ b/packages/cms-editor/src/components/CmsValueField.tsx
@@ -7,7 +7,8 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-  useReadonly
+  useReadonly,
+  type MessageData
 } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { type ChangeEvent, type Dispatch, type SetStateAction } from 'react';
@@ -19,9 +20,10 @@ type CmsValueFieldProps = {
   setValues: Dispatch<SetStateAction<MapStringString>>;
   languageTag: string;
   disabled?: boolean;
+  message?: MessageData;
 };
 
-export const CmsValueField = ({ values, setValues, languageTag, disabled }: CmsValueFieldProps) => {
+export const CmsValueField = ({ values, setValues, languageTag, disabled, message }: CmsValueFieldProps) => {
   const { t } = useTranslation();
   const { languageDisplayName } = useAppContext();
 
@@ -61,6 +63,7 @@ export const CmsValueField = ({ values, setValues, languageTag, disabled }: CmsV
         )
       }
       className='cms-editor-value-field'
+      message={message}
     >
       <Textarea
         value={isValuePresent ? value : ''}

--- a/packages/cms-editor/src/main/control/use-validate-add-content-object.test.ts
+++ b/packages/cms-editor/src/main/control/use-validate-add-content-object.test.ts
@@ -1,0 +1,63 @@
+import type { ContentObject, MapStringString } from '@axonivy/cms-editor-protocol';
+import { customRenderHook } from '../../context/test-utils/test-utils';
+import { useValidateAddContentObject } from './use-validate-add-content-object';
+
+test('nameMessage', () => {
+  expect(renderUseValidateAddContentObject().result.current.nameMessage).toEqual({
+    message: 'Name cannot be empty.',
+    variant: 'error'
+  });
+
+  expect(renderUseValidateAddContentObject({ name: 'test/name' }).result.current.nameMessage).toEqual({
+    message: "Character '/' is not allowed.",
+    variant: 'error'
+  });
+
+  const nameIsTakenMessage = {
+    message: 'Name is already present in this Namespace.',
+    variant: 'error'
+  };
+  expect(
+    renderUseValidateAddContentObject({
+      name: 'testName',
+      contentObjects: [{ uri: '/testName' } as ContentObject]
+    }).result.current.nameMessage
+  ).toEqual(nameIsTakenMessage);
+  expect(
+    renderUseValidateAddContentObject({
+      name: 'testName',
+      namespace: 'testNamespace',
+      contentObjects: [{ uri: '/testNamespace/testName' } as ContentObject]
+    }).result.current.nameMessage
+  ).toEqual(nameIsTakenMessage);
+  expect(
+    renderUseValidateAddContentObject({
+      name: 'tEstNamE',
+      namespace: '/tEstNamEspacE',
+      contentObjects: [{ uri: '/testNamespace/testName' } as ContentObject]
+    }).result.current.nameMessage
+  ).toEqual(nameIsTakenMessage);
+
+  expect(renderUseValidateAddContentObject({ name: 'testName' }).result.current.nameMessage).toBeUndefined();
+});
+
+test('valuesMessage', () => {
+  expect(renderUseValidateAddContentObject().result.current.valuesMessage).toEqual({
+    message: 'Value cannot be empty.',
+    variant: 'error'
+  });
+  expect(renderUseValidateAddContentObject({ values: { en: 'value' } }).result.current.valuesMessage).toBeUndefined();
+});
+
+type renderUseValidateAddContentObjectProps = {
+  name?: string;
+  namespace?: string;
+  values?: MapStringString;
+  contentObjects?: Array<ContentObject>;
+};
+
+const renderUseValidateAddContentObject = (props?: renderUseValidateAddContentObjectProps) => {
+  return customRenderHook(() =>
+    useValidateAddContentObject(props?.name ?? '', props?.namespace ?? '', props?.values ?? {}, props?.contentObjects ?? [])
+  );
+};

--- a/packages/cms-editor/src/main/control/use-validate-add-content-object.ts
+++ b/packages/cms-editor/src/main/control/use-validate-add-content-object.ts
@@ -1,0 +1,42 @@
+import type { ContentObject, MapStringString } from '@axonivy/cms-editor-protocol';
+import type { MessageData } from '@axonivy/ui-components';
+import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export const useValidateAddContentObject = (
+  name: string,
+  namespace: string,
+  values: MapStringString,
+  contentObjects: Array<ContentObject>
+) => {
+  const { t } = useTranslation();
+
+  const nameIsTaken = useCallback(() => {
+    const ns = namespace === '' || namespace.startsWith('/') ? namespace : `/${namespace}`;
+    const uri = `${ns}/${name}`.toLowerCase();
+    return contentObjects.some(co => co.uri.toLowerCase() === uri);
+  }, [contentObjects, name, namespace]);
+
+  const nameMessage = useMemo<MessageData | undefined>(() => {
+    let message;
+    if (name.trim() === '') {
+      message = t('message.emptyName');
+    } else if (name.includes('/')) {
+      message = t('message.notAllowedChar', { character: '/' });
+    } else if (nameIsTaken()) {
+      message = t('message.nameIsTaken');
+    }
+    return toErrorMessage(message);
+  }, [name, nameIsTaken, t]);
+
+  const valuesMessage = useMemo<MessageData | undefined>(() => {
+    if (Object.keys(values).length === 0) {
+      return toErrorMessage(t('message.noValues'));
+    }
+    return undefined;
+  }, [t, values]);
+
+  return { nameMessage, valuesMessage };
+};
+
+const toErrorMessage = (message?: string): MessageData | undefined => (message ? { message: message, variant: 'error' } : undefined);

--- a/packages/cms-editor/src/translation/cms-editor/de.json
+++ b/packages/cms-editor/src/translation/cms-editor/de.json
@@ -15,7 +15,12 @@
   },
   "message": {
     "emptyDetail": "Wähle ein Inhaltsobjekt aus um es zu bearbeiten.",
-    "error": "Ein fehler ist aufgetreten: {{error}}"
+    "emptyName": "Name darf nicht leer sein.",
+    "error": "Ein fehler ist aufgetreten: {{error}}",
+    "nameIsTaken": "Name ist bereits vorhanden in diesem Namensbereich.",
+    "namespaceInfo": "Ordnerstruktur des Inhaltsobjekts (z.B. '/Dialog/Label').",
+    "notAllowedChar": "Zeichen '{{- character}}' ist nicht erlaubt.",
+    "noValues": "Wert darf nicht leer sein."
   },
   "value": {
     "delete": "Wert löschen",

--- a/packages/cms-editor/src/translation/cms-editor/en.json
+++ b/packages/cms-editor/src/translation/cms-editor/en.json
@@ -15,7 +15,12 @@
   },
   "message": {
     "emptyDetail": "Select a Content Object to edit its values.",
-    "error": "An error has occurred: {{error}}"
+    "emptyName": "Name cannot be empty.",
+    "error": "An error has occurred: {{error}}",
+    "nameIsTaken": "Name is already present in this Namespace.",
+    "namespaceInfo": "Folder structure of Content Object (e.g. '/Dialog/Label').",
+    "notAllowedChar": "Character '{{- character}}' is not allowed.",
+    "noValues": "Value cannot be empty."
   },
   "value": {
     "delete": "Delete value",

--- a/playwright/tests/integration/mock/detail.spec.ts
+++ b/playwright/tests/integration/mock/detail.spec.ts
@@ -15,16 +15,16 @@ test('empty while no selecton', async () => {
 test('uri', async () => {
   const uri = editor.detail.uri;
   await editor.main.table.row(0).locator.click();
-  await expect(uri).toBeDisabled();
-  await expect(uri).toHaveValue('/Dialogs/agileBPM/define_WF/AddTask');
+  await expect(uri.locator).toBeDisabled();
+  await expect(uri.locator).toHaveValue('/Dialogs/agileBPM/define_WF/AddTask');
   await editor.main.table.row(1).locator.click();
-  await expect(uri).toBeDisabled();
-  await expect(uri).toHaveValue('/Dialogs/agileBPM/define_WF/AdhocWorkflowTasks');
+  await expect(uri.locator).toBeDisabled();
+  await expect(uri.locator).toHaveValue('/Dialogs/agileBPM/define_WF/AdhocWorkflowTasks');
 });
 
 test('a field for each locale', async () => {
   await editor.main.table.row(2).locator.click();
   await expect(editor.detail.values).toHaveCount(2);
-  await expect(editor.detail.value('English').textbox).toHaveValue('Case');
-  await expect(editor.detail.value('German').textbox).toHaveValue('Fall');
+  await expect(editor.detail.value('English').textbox.locator).toHaveValue('Case');
+  await expect(editor.detail.value('German').textbox.locator).toHaveValue('Fall');
 });

--- a/playwright/tests/integration/mock/main.spec.ts
+++ b/playwright/tests/integration/mock/main.spec.ts
@@ -8,9 +8,9 @@ test.beforeEach(async ({ page }) => {
 });
 
 test('search', async () => {
-  await editor.main.search.fill('hello');
+  await editor.main.search.locator.fill('hello');
   await expect(editor.main.table.rows).toHaveCount(0);
-  await editor.main.search.fill('tasks');
+  await editor.main.search.locator.fill('tasks');
   await expect(editor.main.table.rows).toHaveCount(3);
 });
 

--- a/playwright/tests/pageobjects/abstract/Message.ts
+++ b/playwright/tests/pageobjects/abstract/Message.ts
@@ -1,0 +1,25 @@
+import { expect, type Locator } from '@playwright/test';
+
+export class Message {
+  readonly locator: Locator;
+
+  constructor(parent: Locator, options?: { id?: string; className?: string }) {
+    if (options?.id) {
+      this.locator = parent.locator(`[id="${options.id}"]`);
+    } else if (options?.className) {
+      this.locator = parent.locator(`.ui-message.${options.className}`);
+    } else {
+      this.locator = parent.locator('.ui-message').first();
+    }
+  }
+
+  async expectToBeInfo(message: string) {
+    await expect(this.locator).toHaveText(message);
+    await expect(this.locator).toHaveAttribute('data-state', 'info');
+  }
+
+  async expectToBeError(message: string) {
+    await expect(this.locator).toHaveText(message);
+    await expect(this.locator).toHaveAttribute('data-state', 'error');
+  }
+}

--- a/playwright/tests/pageobjects/abstract/Textbox.ts
+++ b/playwright/tests/pageobjects/abstract/Textbox.ts
@@ -1,0 +1,24 @@
+import { type Locator } from '@playwright/test';
+import { Message } from './Message';
+
+export class Textbox {
+  readonly parent: Locator;
+  readonly locator: Locator;
+
+  constructor(parent: Locator, options?: { name?: string; nth?: number }) {
+    this.parent = parent;
+    if (options?.name) {
+      this.locator = parent.getByRole('textbox', { name: options.name, exact: true });
+    } else {
+      this.locator = parent.getByRole('textbox').nth(options?.nth ?? 0);
+    }
+  }
+
+  async message() {
+    const describedBy = await this.locator.getAttribute('aria-describedby');
+    if (!describedBy) {
+      throw new Error('aria-describedby attribute is missing');
+    }
+    return new Message(this.parent, { id: describedBy });
+  }
+}

--- a/playwright/tests/pageobjects/components/CmsValueField.ts
+++ b/playwright/tests/pageobjects/components/CmsValueField.ts
@@ -1,10 +1,11 @@
 import type { Locator, Page } from '@playwright/test';
+import { Textbox } from '../abstract/Textbox';
 
 export class CmsValueField {
   readonly locator: Locator;
   readonly label: Locator;
   readonly delete: Locator;
-  readonly textbox: Locator;
+  readonly textbox: Textbox;
 
   constructor(page: Page, parent: Locator, options?: { label?: string; nth?: number }) {
     if (options?.label) {
@@ -14,6 +15,6 @@ export class CmsValueField {
     }
     this.label = this.locator.locator('label');
     this.delete = this.locator.getByRole('button');
-    this.textbox = this.locator.getByRole('textbox');
+    this.textbox = new Textbox(this.locator);
   }
 }

--- a/playwright/tests/pageobjects/detail/DetailPanel.ts
+++ b/playwright/tests/pageobjects/detail/DetailPanel.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator, type Page } from '@playwright/test';
+import { Textbox } from '../abstract/Textbox';
 import { CmsValueField } from '../components/CmsValueField';
 import { DetailToolbar } from './DetailToolbar';
 
@@ -6,7 +7,7 @@ export class DetailPanel {
   readonly page: Page;
   readonly locator: Locator;
   readonly toolbar: DetailToolbar;
-  readonly uri: Locator;
+  readonly uri: Textbox;
   readonly values: Locator;
   readonly message: Locator;
 
@@ -14,7 +15,7 @@ export class DetailPanel {
     this.page = page;
     this.locator = this.page.locator('.cms-editor-detail-panel');
     this.toolbar = new DetailToolbar(this.locator);
-    this.uri = this.locator.getByRole('textbox', { name: 'URI' });
+    this.uri = new Textbox(this.locator, { name: 'URI' });
     this.values = this.locator.locator('.cms-editor-value-field');
     this.message = this.locator.locator('p');
   }
@@ -24,9 +25,9 @@ export class DetailPanel {
   }
 
   async expectToHaveValues(uri: string, values: Record<string, string>) {
-    await expect(this.uri).toHaveValue(uri);
+    await expect(this.uri.locator).toHaveValue(uri);
     for (const [language, value] of Object.entries(values)) {
-      await expect(this.value(language).textbox).toHaveValue(value);
+      await expect(this.value(language).textbox.locator).toHaveValue(value);
     }
   }
 }

--- a/playwright/tests/pageobjects/main/AddContentObject.ts
+++ b/playwright/tests/pageobjects/main/AddContentObject.ts
@@ -1,31 +1,33 @@
 import { expect, type Locator, type Page } from '@playwright/test';
+import { Message } from '../abstract/Message';
+import { Textbox } from '../abstract/Textbox';
 import { CmsValueField } from '../components/CmsValueField';
 
 export class AddContentObject {
   readonly locator: Locator;
   readonly trigger: Locator;
-  readonly name: Locator;
-  readonly namespace: Locator;
+  readonly name: Textbox;
+  readonly namespace: Textbox;
   readonly value: CmsValueField;
-  readonly error: Locator;
+  readonly error: Message;
   readonly create: Locator;
 
   constructor(page: Page, parent: Locator) {
     this.locator = page.getByRole('dialog');
     this.trigger = parent.locator('.cms-editor-main-control').getByRole('button').first();
-    this.name = this.locator.getByRole('textbox', { name: 'Name', exact: true });
-    this.namespace = this.locator.getByRole('textbox', { name: 'Namespace' });
+    this.name = new Textbox(this.locator, { name: 'Name' });
+    this.namespace = new Textbox(this.locator, { name: 'Namespace' });
     this.value = new CmsValueField(page, this.locator);
-    this.error = this.locator.locator('.cms-editor-add-dialog-error-message');
+    this.error = new Message(this.locator, { className: 'cms-editor-add-dialog-error-message' });
     this.create = this.locator.getByRole('button', { name: 'Create Content Object' });
   }
 
   async add(name: string, namespace: string, value: string) {
     await this.trigger.click();
     await expect(this.locator).toBeVisible();
-    await this.name.fill(name);
-    await this.namespace.fill(namespace);
-    await this.value.textbox.fill(value);
+    await this.name.locator.fill(name);
+    await this.namespace.locator.fill(namespace);
+    await this.value.textbox.locator.fill(value);
     await this.create.click();
     await expect(this.locator).toBeHidden();
   }

--- a/playwright/tests/pageobjects/main/MainPanel.ts
+++ b/playwright/tests/pageobjects/main/MainPanel.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from '@playwright/test';
+import { Textbox } from '../abstract/Textbox';
 import { AddContentObject } from './AddContentObject';
 import { MainToolbar } from './MainToolbar';
 import { Table } from './Table';
@@ -8,7 +9,7 @@ export class MainPanel {
   readonly toolbar: MainToolbar;
   readonly label: Locator;
   readonly add: AddContentObject;
-  readonly search: Locator;
+  readonly search: Textbox;
   readonly table: Table;
 
   constructor(page: Page) {
@@ -16,7 +17,7 @@ export class MainPanel {
     this.toolbar = new MainToolbar(page, this.locator);
     this.label = this.locator.locator('.cms-editor-main-table-field').locator('label');
     this.add = new AddContentObject(page, this.locator);
-    this.search = this.locator.getByRole('textbox').first();
+    this.search = new Textbox(this.locator);
     this.table = new Table(this.locator);
   }
 }


### PR DESCRIPTION
Validate the fields of the add dialog and disable creating a Content Object if not all fields are valid.

name:
- Cannot be empty.
- Cannot exist in the given namespace.

value:
- Cannot be missing.