### PR TITLE
XIVY-15944 add language tool

### DIFF
--- a/integrations/standalone/src/mock/cms-client-mock.ts
+++ b/integrations/standalone/src/mock/cms-client-mock.ts
@@ -9,10 +9,11 @@ import type {
   CmsDeleteValueArgs,
   CmsReadArgs,
   CmsUpdateValueArgs,
+  MetaRequestTypes,
   Void
 } from '@axonivy/cms-editor-protocol';
 import { contentObjects } from './data';
-import { locales } from './meta';
+import { locales, supportedLocales } from './meta';
 
 export class CmsClientMock implements Client {
   private cmsData: CmsData = contentObjects;
@@ -55,8 +56,15 @@ export class CmsClientMock implements Client {
     this.cmsData = { ...this.cmsData, data: this.cmsData.data.filter(co => co.uri !== args.uri) };
   }
 
-  meta(): Promise<Array<string>> {
-    return Promise.resolve(locales);
+  meta<TMeta extends keyof MetaRequestTypes>(path: TMeta): Promise<Array<string>> {
+    switch (path) {
+      case 'meta/supportedLocales':
+        return Promise.resolve(supportedLocales);
+      case 'meta/locales':
+        return Promise.resolve(locales);
+      default:
+        throw Error('meta path not implemented');
+    }
   }
 
   action(action: CmsActionArgs): void {

--- a/integrations/standalone/src/mock/meta.ts
+++ b/integrations/standalone/src/mock/meta.ts
@@ -1,1 +1,2 @@
+export const supportedLocales: Array<string> = ['en', 'en-US', 'en-GB', 'de', 'de-AT', 'de-CH', 'de-DE'];
 export const locales: Array<string> = ['en', 'de'];

--- a/packages/cms-editor/src/CmsEditor.tsx
+++ b/packages/cms-editor/src/CmsEditor.tsx
@@ -29,7 +29,7 @@ function CmsEditor(props: EditorProps) {
   const client = useClient();
   const { dataKey } = useQueryKeys();
 
-  const { defaultLanguageTag, languageDisplayName } = useLanguage(context);
+  const { defaultLanguageTag, setDefaultLanguageTag, languageDisplayName } = useLanguage(context);
   const { data, isPending, isError, error } = useQuery({
     queryKey: dataKey({ context, languageTags: [defaultLanguageTag] }),
     queryFn: async () => await client.data({ context, languageTags: [defaultLanguageTag] }),
@@ -67,6 +67,7 @@ function CmsEditor(props: EditorProps) {
         detail,
         setDetail,
         defaultLanguageTag,
+        setDefaultLanguageTag,
         languageDisplayName
       }}
     >

--- a/packages/cms-editor/src/context/AppContext.tsx
+++ b/packages/cms-editor/src/context/AppContext.tsx
@@ -9,6 +9,7 @@ type AppContext = {
   detail: boolean;
   setDetail: (visible: boolean) => void;
   defaultLanguageTag: string;
+  setDefaultLanguageTag: (languageTag: string) => void;
   languageDisplayName: Intl.DisplayNames;
 };
 
@@ -20,6 +21,7 @@ const appContext = createContext<AppContext>({
   detail: true,
   setDetail: () => {},
   defaultLanguageTag: '',
+  setDefaultLanguageTag: () => {},
   languageDisplayName: new Intl.DisplayNames(undefined, { type: 'language' })
 });
 

--- a/packages/cms-editor/src/context/test-utils/test-utils.tsx
+++ b/packages/cms-editor/src/context/test-utils/test-utils.tsx
@@ -26,6 +26,7 @@ type ContextHelperProps = {
     detail?: boolean;
     setDetail?: (visible: boolean) => void;
     defaultLanguageTag?: string;
+    setDefaultLanguageTag?: (languageTag: string) => void;
     languageDisplayName?: Intl.DisplayNames;
   };
 };
@@ -60,6 +61,7 @@ const ContextHelper = ({
     detail: appContext?.detail !== undefined ? appContext.detail : true,
     setDetail: appContext?.setDetail ?? (() => {}),
     defaultLanguageTag: appContext?.defaultLanguageTag ?? '',
+    setDefaultLanguageTag: appContext?.setDefaultLanguageTag ?? (() => {}),
     languageDisplayName: appContext?.languageDisplayName ?? ({} as Intl.DisplayNames)
   };
 

--- a/packages/cms-editor/src/main/control/LanguageTool.tsx
+++ b/packages/cms-editor/src/main/control/LanguageTool.tsx
@@ -1,0 +1,92 @@
+import {
+  BasicField,
+  BasicSelect,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  Flex,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+  useHotkeys
+} from '@axonivy/ui-components';
+import { IvyIcons } from '@axonivy/ui-icons';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAppContext } from '../../context/AppContext';
+import { useMeta } from '../../protocol/use-meta';
+import { useKnownHotkeys } from '../../utils/hotkeys';
+
+export const LanguageTool = () => {
+  const { t } = useTranslation();
+
+  const [open, setOpen] = useState(false);
+  const onOpenChange = (open: boolean) => {
+    setOpen(open);
+    if (open) {
+      initializeDialog();
+    }
+  };
+
+  const { defaultLanguageTag, setDefaultLanguageTag, languageDisplayName } = useAppContext();
+  const [defaultLanguage, setDefaultLanguage] = useState(defaultLanguageTag);
+
+  const initializeDialog = () => {
+    setDefaultLanguage(defaultLanguageTag);
+  };
+
+  const languages = useMeta('meta/supportedLocales', null, []).data;
+  const languageItems = useMemo(
+    () =>
+      languages
+        .map(language => ({ value: language, label: languageDisplayName.of(language) ?? language }))
+        .sort((option1, option2) => option1.label.localeCompare(option2.label)),
+    [languageDisplayName, languages]
+  );
+
+  const save = () => {
+    setDefaultLanguageTag(defaultLanguage);
+    setOpen(false);
+  };
+
+  const { languageTool: shortcut } = useKnownHotkeys();
+  useHotkeys(shortcut.hotkey, () => onOpenChange(true), { scopes: ['global'], keyup: true, enabled: !open });
+  const enter = useHotkeys(['Enter'], () => save(), { scopes: ['global'], enabled: open, enableOnFormTags: true });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DialogTrigger asChild>
+              <Button icon={IvyIcons.WsStart} aria-label={shortcut.label} />
+            </DialogTrigger>
+          </TooltipTrigger>
+          <TooltipContent>{shortcut.label}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('dialog.languageTool.title')}</DialogTitle>
+        </DialogHeader>
+        <DialogDescription>{t('dialog.languageTool.description')}</DialogDescription>
+        <Flex direction='column' gap={3} ref={enter} tabIndex={-1}>
+          <BasicField label={t('dialog.languageTool.label.defaultLanguage')}>
+            <BasicSelect value={defaultLanguage} onValueChange={setDefaultLanguage} items={languageItems} />
+          </BasicField>
+        </Flex>
+        <DialogFooter>
+          <Button variant='primary' size='large' aria-label={t('dialog.languageTool.save')} onClick={save}>
+            {t('dialog.languageTool.save')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/packages/cms-editor/src/main/control/MainControl.tsx
+++ b/packages/cms-editor/src/main/control/MainControl.tsx
@@ -1,6 +1,7 @@
 import { Flex, Separator } from '@axonivy/ui-components';
 import { AddContentObject } from './AddContentObject';
 import { DeleteContentObject } from './DeleteContentObject';
+import { LanguageTool } from './LanguageTool';
 
 type MainControlProps = {
   selectRow: (rowId: string) => void;
@@ -10,6 +11,8 @@ type MainControlProps = {
 
 export const MainControl = ({ selectRow, deleteContentObject, hasSelection }: MainControlProps) => (
   <Flex gap={2} className='cms-editor-main-control'>
+    <LanguageTool />
+    <Separator decorative orientation='vertical' style={{ height: '20px', margin: 0 }} />
     <AddContentObject selectRow={selectRow} />
     <Separator decorative orientation='vertical' style={{ height: '20px', margin: 0 }} />
     <DeleteContentObject deleteContentObject={deleteContentObject} hasSelection={hasSelection} />

--- a/packages/cms-editor/src/translation/cms-editor/de.json
+++ b/packages/cms-editor/src/translation/cms-editor/de.json
@@ -20,11 +20,20 @@
       "createTooltip": "Halte {{modifier}} um ein weiteres Inhaltsobjekt zu erstellen.",
       "description": "Wählen Sie den Namen, den Namensbereich und die Werte des Inhaltsobjekts, das Sie hinzufügen möchten.",
       "title": "Inhaltsobjekt hinzufügen"
+    },
+    "languageTool": {
+      "description": "Bearbeite die Sprachen des CMS.",
+      "label": {
+        "defaultLanguage": "Standardsprache"
+      },
+      "save": "Speichern",
+      "title": "Sprachwerkzeug"
     }
   },
   "hotkey": {
     "addContentObject": "Inhaltsobjekt hinzufügen ({{hotkey}})",
-    "deleteContentObject": "Inhaltsobjekt löschen ({{hotkey}})"
+    "deleteContentObject": "Inhaltsobjekt löschen ({{hotkey}})",
+    "languageTool": "Sprachwerkzeug ({{hotkey}})"
   },
   "label": {
     "contentObjects": "Inhaltsobjekte"

--- a/packages/cms-editor/src/translation/cms-editor/en.json
+++ b/packages/cms-editor/src/translation/cms-editor/en.json
@@ -20,11 +20,20 @@
       "createTooltip": "Hold {{modifier}} to add an additional Content Object.",
       "description": "Choose the name, namespace, and values of the Content Object you want to add.",
       "title": "Add Content Object"
+    },
+    "languageTool": {
+      "description": "Edit the languages of the CMS.",
+      "label": {
+        "defaultLanguage": "Default Language"
+      },
+      "save": "Save",
+      "title": "Language Tool"
     }
   },
   "hotkey": {
     "addContentObject": "Add Content Object ({{hotkey}})",
-    "deleteContentObject": "Delete Content Object ({{hotkey}})"
+    "deleteContentObject": "Delete Content Object ({{hotkey}})",
+    "languageTool": "Language Tool ({{hotkey}})"
   },
   "label": {
     "contentObjects": "Content Objects"

--- a/packages/cms-editor/src/use-language.test.ts
+++ b/packages/cms-editor/src/use-language.test.ts
@@ -1,9 +1,24 @@
 import type { Client, CmsEditorDataContext } from '@axonivy/cms-editor-protocol';
 import { waitFor } from '@testing-library/react';
 import { customRenderHook } from './context/test-utils/test-utils';
-import { useLanguage } from './use-language';
+import { defaultLanguageTagKey, useLanguage } from './use-language';
 
-test('useLanguage', async () => {
+afterEach(() => localStorage.clear());
+
+test('default language set via local storage', async () => {
+  localStorage.setItem(defaultLanguageTagKey, 'en');
+  const view = renderLanguageHook('de', []);
+  expect(view.result.current.defaultLanguageTag).toEqual('en');
+  expect(view.result.current.languageDisplayName.resolvedOptions().locale).toEqual('de');
+
+  view.result.current.setDefaultLanguageTag('ja');
+  view.rerender();
+  expect(view.result.current.defaultLanguageTag).toEqual('ja');
+  expect(view.result.current.languageDisplayName.resolvedOptions().locale).toEqual('de');
+  expect(localStorage.getItem(defaultLanguageTagKey)).toEqual('ja');
+});
+
+test('default language not set via local storage', async () => {
   let result = renderLanguageHook('de', []).result;
   expect(result.current.defaultLanguageTag).toEqual('de');
   expect(result.current.languageDisplayName.resolvedOptions().locale).toEqual('de');

--- a/packages/cms-editor/src/use-language.ts
+++ b/packages/cms-editor/src/use-language.ts
@@ -1,19 +1,30 @@
 import type { CmsEditorDataContext } from '@axonivy/cms-editor-protocol';
 import i18next from 'i18next';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useMeta } from './protocol/use-meta';
+
+export const defaultLanguageTagKey = 'defaultLanguageTag' as const;
 
 export const useLanguage = (context: CmsEditorDataContext) => {
   const clientLanguageTag = i18next.language;
   const languageDisplayName = useMemo(() => new Intl.DisplayNames([clientLanguageTag], { type: 'language' }), [clientLanguageTag]);
 
   const locales = useMeta('meta/locales', context, []);
-  const defaultLanguageTag = useMemo(() => defaultLanguage(locales.data, clientLanguageTag), [locales.data, clientLanguageTag]);
+  const [defaultLanguageTag, setDefaultLanguageTagState] = useState(defaultLanguage(locales.data, clientLanguageTag));
+  const setDefaultLanguageTag = (languageTag: string) => {
+    setDefaultLanguageTagState(languageTag);
+    localStorage.setItem(defaultLanguageTagKey, languageTag);
+  };
+  useEffect(() => setDefaultLanguageTagState(defaultLanguage(locales.data, clientLanguageTag)), [locales.data, clientLanguageTag]);
 
-  return { defaultLanguageTag, languageDisplayName };
+  return { defaultLanguageTag, setDefaultLanguageTag, languageDisplayName };
 };
 
 const defaultLanguage = (locales: Array<string>, clientLanguageTag: string) => {
+  const defaultLanguageTag = localStorage.getItem(defaultLanguageTagKey);
+  if (defaultLanguageTag) {
+    return defaultLanguageTag;
+  }
   if (locales.includes(clientLanguageTag) || locales.length === 0) {
     return clientLanguageTag;
   }

--- a/packages/cms-editor/src/utils/hotkeys.ts
+++ b/packages/cms-editor/src/utils/hotkeys.ts
@@ -11,6 +11,11 @@ export const useKnownHotkeys = () => {
     return { hotkey, label: t('common.hotkey.help', { hotkey: hotkeyText(hotkey) }) };
   }, [t]);
 
+  const languageTool = useMemo<KnownHotkey>(() => {
+    const hotkey = 'L';
+    return { hotkey, label: t('hotkey.languageTool', { hotkey: hotkeyText(hotkey) }) };
+  }, [t]);
+
   const addContentObject = useMemo<KnownHotkey>(() => {
     const hotkey = 'A';
     return { hotkey, label: t('hotkey.addContentObject', { hotkey: hotkeyText(hotkey) }) };
@@ -36,5 +41,5 @@ export const useKnownHotkeys = () => {
     return { hotkey, label: t('common.hotkey.focusInscription', { hotkey: hotkeyText(hotkey) }) };
   }, [t]);
 
-  return { openHelp, addContentObject, deleteContentObject, focusToolbar, focusMain, focusInscription };
+  return { openHelp, languageTool, addContentObject, deleteContentObject, focusToolbar, focusMain, focusInscription };
 };

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -32,6 +32,7 @@ export interface ClientContext {
 }
 
 export interface MetaRequestTypes {
+  'meta/supportedLocales': [null, Array<string>];
   'meta/locales': [CmsEditorDataContext, Array<string>];
 }
 

--- a/playwright/tests/integration/mock/add.spec.ts
+++ b/playwright/tests/integration/mock/add.spec.ts
@@ -32,15 +32,15 @@ test('default values', async () => {
 
 test('show field for value of default language', async ({ page }) => {
   editor = await CmsEditor.openMock(page, { lng: 'ja' });
-  await editor.main.control.add.trigger.click();
+  await editor.page.keyboard.press('a');
   await expect(editor.main.control.add.value.label).toHaveText('英語');
 
   editor = await CmsEditor.openMock(page, { lng: 'en' });
-  await editor.main.control.add.trigger.click();
+  await editor.page.keyboard.press('a');
   await expect(editor.main.control.add.value.label).toHaveText('English');
 
   editor = await CmsEditor.openMock(page, { lng: 'de' });
-  await editor.main.control.add.trigger.click();
+  await editor.page.keyboard.press('a');
   await expect(editor.main.control.add.value.label).toHaveText('Deutsch');
 });
 

--- a/playwright/tests/integration/mock/language-tool.spec.ts
+++ b/playwright/tests/integration/mock/language-tool.spec.ts
@@ -1,0 +1,42 @@
+import test, { expect } from '@playwright/test';
+import { CmsEditor } from '../../pageobjects/CmsEditor';
+
+let editor: CmsEditor;
+
+test.beforeEach(async ({ page }) => {
+  editor = await CmsEditor.openMock(page);
+});
+
+test('default language', async () => {
+  await expect(editor.main.table.header(1).content).toHaveText('English');
+  await editor.main.control.languageTool.trigger.click();
+  await editor.main.control.languageTool.defaultLanguage.select('German');
+  await editor.main.control.languageTool.save.click();
+  await expect(editor.main.table.header(1).content).toHaveText('German');
+});
+
+test('keyboard support', async () => {
+  await expect(editor.main.table.header(1).content).toHaveText('English');
+  await expect(editor.main.control.languageTool.locator).toBeHidden();
+
+  await editor.page.keyboard.press('l');
+  await expect(editor.main.control.languageTool.locator).toBeVisible();
+
+  await editor.main.control.languageTool.defaultLanguage.select('German');
+  await editor.page.keyboard.press('Enter');
+  await expect(editor.main.control.languageTool.locator).toBeHidden();
+  await expect(editor.main.table.header(1).content).toHaveText('German');
+});
+
+test('options', async () => {
+  await editor.main.control.languageTool.trigger.click();
+  await editor.main.control.languageTool.defaultLanguage.expectToHaveOptions(
+    'American English',
+    'Austrian German',
+    'British English',
+    'English',
+    'German',
+    'German (Germany)',
+    'Swiss High German'
+  );
+});

--- a/playwright/tests/pageobjects/abstract/Select.ts
+++ b/playwright/tests/pageobjects/abstract/Select.ts
@@ -1,0 +1,29 @@
+import type { Locator, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+export class Select {
+  readonly locator: Locator;
+  readonly options: Locator;
+
+  constructor(page: Page, parent: Locator, options?: { name?: string }) {
+    if (options?.name) {
+      this.locator = parent.getByRole('combobox', { name: options.name, exact: true });
+    } else {
+      this.locator = parent.getByRole('combobox').first();
+    }
+    this.options = page.getByRole('option');
+  }
+
+  async select(option: string) {
+    await this.locator.click();
+    await this.options.getByText(option, { exact: true }).click();
+  }
+
+  async expectToHaveOptions(...options: Array<string>) {
+    await this.locator.click();
+    await expect(this.options).toHaveCount(options.length);
+    for (let i = 0; i < options.length; i++) {
+      await expect(this.options.nth(i)).toHaveText(options[i]);
+    }
+  }
+}

--- a/playwright/tests/pageobjects/main/AddContentObject.ts
+++ b/playwright/tests/pageobjects/main/AddContentObject.ts
@@ -15,7 +15,7 @@ export class AddContentObject {
 
   constructor(page: Page, parent: Locator) {
     this.locator = page.getByRole('dialog');
-    this.trigger = parent.getByRole('button').first();
+    this.trigger = parent.getByRole('button', { name: 'Add Content Object' });
     this.name = new Textbox(this.locator, { name: 'Name' });
     this.namespace = new Combobox(this.locator, { name: 'Namespace' });
     this.value = new CmsValueField(page, this.locator);

--- a/playwright/tests/pageobjects/main/Control.ts
+++ b/playwright/tests/pageobjects/main/Control.ts
@@ -1,14 +1,17 @@
 import type { Locator, Page } from '@playwright/test';
 import { AddContentObject } from './AddContentObject';
+import { LanguageTool } from './LanguageTool';
 
 export class Control {
   readonly locator: Locator;
+  readonly languageTool: LanguageTool;
   readonly add: AddContentObject;
   readonly delete: Locator;
 
   constructor(page: Page, parent: Locator) {
     this.locator = parent.locator('.cms-editor-main-control');
     this.add = new AddContentObject(page, this.locator);
+    this.languageTool = new LanguageTool(page, this.locator);
     this.delete = this.locator.getByRole('button', { name: 'Delete Content Object' });
   }
 }

--- a/playwright/tests/pageobjects/main/LanguageTool.ts
+++ b/playwright/tests/pageobjects/main/LanguageTool.ts
@@ -1,0 +1,16 @@
+import type { Locator, Page } from '@playwright/test';
+import { Select } from '../abstract/Select';
+
+export class LanguageTool {
+  readonly locator: Locator;
+  readonly trigger: Locator;
+  readonly defaultLanguage: Select;
+  readonly save: Locator;
+
+  constructor(page: Page, parent: Locator) {
+    this.locator = page.getByRole('dialog');
+    this.trigger = parent.getByRole('button', { name: 'Language Tool' });
+    this.defaultLanguage = new Select(page, this.locator, { name: 'Default Language' });
+    this.save = this.locator.getByRole('button', { name: 'Save' });
+  }
+}


### PR DESCRIPTION
The language tool allows a user to select a default language.
- The default language is saved in the local storage.
- The default language is used to determine for which language to display a column in the table and a field in the "Add Content Object" dialog.
- The language tool can be opened via the keyboard shortcut "L" and changes can be saved by pressing "Enter".
- The possible languages to select are determined via the LSP endpoint "meta/supportedLocales".