### PR TITLE
XIVY-15944 allow deleting languages using language tool

### DIFF
--- a/integrations/standalone/src/mock/cms-client-mock.ts
+++ b/integrations/standalone/src/mock/cms-client-mock.ts
@@ -8,6 +8,7 @@ import type {
   CmsDeleteArgs,
   CmsDeleteValueArgs,
   CmsReadArgs,
+  CmsRemoveLocalesArgs,
   CmsUpdateValueArgs,
   MetaRequestTypes,
   Void
@@ -17,6 +18,7 @@ import { locales, supportedLocales } from './meta';
 
 export class CmsClientMock implements Client {
   private cmsData: CmsData = contentObjects;
+  private localesData: Array<string> = locales;
 
   data(): Promise<CmsData> {
     return Promise.resolve(this.cmsData);
@@ -56,12 +58,15 @@ export class CmsClientMock implements Client {
     this.cmsData = { ...this.cmsData, data: this.cmsData.data.filter(co => co.uri !== args.uri) };
   }
 
-  meta<TMeta extends keyof MetaRequestTypes>(path: TMeta): Promise<Array<string>> {
+  meta<TMeta extends keyof MetaRequestTypes>(path: TMeta, args: MetaRequestTypes[TMeta][0]): Promise<MetaRequestTypes[TMeta][1]> {
     switch (path) {
       case 'meta/supportedLocales':
         return Promise.resolve(supportedLocales);
       case 'meta/locales':
-        return Promise.resolve(locales);
+        return Promise.resolve(this.localesData);
+      case 'meta/removeLocales':
+        this.localesData = this.localesData.filter(locale => !(args as CmsRemoveLocalesArgs).locales.includes(locale));
+        return Promise.resolve({});
       default:
         throw Error('meta path not implemented');
     }

--- a/packages/cms-editor/src/main/MainContent.tsx
+++ b/packages/cms-editor/src/main/MainContent.tsx
@@ -138,7 +138,7 @@ export const MainContent = () => {
   const ref = useHotkeys(hotkeys.deleteContentObject.hotkey, () => deleteContentObject(), { scopes: ['global'], enabled: !readonly });
 
   return (
-    <Flex direction='column' onClick={() => selectRow(table)} className='cms-editor-main-content' ref={ref}>
+    <Flex direction='column' onClick={() => table.resetRowSelection()} className='cms-editor-main-content' ref={ref}>
       <BasicField
         label={t('label.contentObjects')}
         control={
@@ -158,7 +158,7 @@ export const MainContent = () => {
         {globalFilter.filter}
         <div ref={tableContainer} className='cms-editor-main-table-container'>
           <Table onKeyDown={event => handleKeyDown(event, () => setDetail(!detail))} className='cms-editor-main-table'>
-            <TableResizableHeader headerGroups={table.getHeaderGroups()} onClick={() => selectRow(table)} />
+            <TableResizableHeader headerGroups={table.getHeaderGroups()} onClick={() => table.resetRowSelection()} />
             <TableBody style={{ height: `${virtualizer.getTotalSize()}px` }}>
               {virtualizer.getVirtualItems().map(virtualRow => {
                 const row = rows[virtualRow.index];

--- a/packages/cms-editor/src/main/control/LanguageTool.tsx
+++ b/packages/cms-editor/src/main/control/LanguageTool.tsx
@@ -1,7 +1,9 @@
+import type { CmsData, CmsRemoveLocalesArgs } from '@axonivy/cms-editor-protocol';
 import {
   BasicField,
   BasicSelect,
   Button,
+  deleteFirstSelectedRow,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -10,20 +12,31 @@ import {
   DialogTitle,
   DialogTrigger,
   Flex,
+  SelectRow,
+  Table,
+  TableBody,
+  TableCell,
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-  useHotkeys
+  useHotkeys,
+  useTableKeyHandler,
+  useTableSelect
 } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
-import { useMemo, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { flexRender, getCoreRowModel, useReactTable, type ColumnDef } from '@tanstack/react-table';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppContext } from '../../context/AppContext';
+import { useClient } from '../../protocol/ClientContextProvider';
 import { useMeta } from '../../protocol/use-meta';
+import { genQueryKey, useQueryKeys } from '../../query/query-client';
 import { useKnownHotkeys } from '../../utils/hotkeys';
 
 export const LanguageTool = () => {
+  const { context, defaultLanguageTag, setDefaultLanguageTag, languageDisplayName } = useAppContext();
   const { t } = useTranslation();
 
   const [open, setOpen] = useState(false);
@@ -34,29 +47,78 @@ export const LanguageTool = () => {
     }
   };
 
-  const { defaultLanguageTag, setDefaultLanguageTag, languageDisplayName } = useAppContext();
   const [defaultLanguage, setDefaultLanguage] = useState(defaultLanguageTag);
+  const [languages, setLanguages] = useState<Array<Language>>([]);
+
+  const deleteSelectedLanguage = () => {
+    const { newData } = deleteFirstSelectedRow(table, languages);
+    setLanguages(newData);
+  };
+
+  const locales = useMeta('meta/locales', context, []).data;
 
   const initializeDialog = () => {
     setDefaultLanguage(defaultLanguageTag);
+    setLanguages(
+      locales
+        .map(locale => ({ value: locale, label: languageDisplayName.of(locale) ?? locale }))
+        .sort((option1, option2) => option1.label.localeCompare(option2.label))
+    );
+    table.resetRowSelection();
   };
 
-  const languages = useMeta('meta/supportedLocales', null, []).data;
-  const languageItems = useMemo(
-    () =>
-      languages
-        .map(language => ({ value: language, label: languageDisplayName.of(language) ?? language }))
-        .sort((option1, option2) => option1.label.localeCompare(option2.label)),
-    [languageDisplayName, languages]
-  );
+  const selection = useTableSelect();
+  const columns: Array<ColumnDef<Language, string>> = [
+    {
+      accessorKey: 'label',
+      cell: cell => <span>{cell.getValue()}</span>
+    }
+  ];
+  const table = useReactTable<Language>({
+    ...selection.options,
+    data: languages,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    state: {
+      ...selection.tableState
+    }
+  });
+
+  const { handleKeyDown } = useTableKeyHandler({ table, data: languages });
+
+  const client = useClient();
+  const queryClient = useQueryClient();
+  const { dataKey } = useQueryKeys();
+
+  const deleteMutation = useMutation({
+    mutationFn: async (args: CmsRemoveLocalesArgs) => {
+      queryClient.setQueryData<Array<string>>(genQueryKey('meta/locales', context), locales =>
+        locales?.filter(locale => !args.locales.includes(locale))
+      );
+      if (args.locales.includes(defaultLanguageTag)) {
+        queryClient.setQueryData<CmsData>(dataKey({ context, languageTags: [defaultLanguageTag] }), data => {
+          if (!data) {
+            return;
+          }
+          return { ...data, data: data.data.map(co => ({ ...co, values: {} })) };
+        });
+      }
+      client.meta('meta/removeLocales', { context, locales: args.locales });
+    }
+  });
 
   const save = () => {
     setDefaultLanguageTag(defaultLanguage);
+    const localesToDelete = locales.filter(locale => !languages.some(language => language.value === locale));
+    if (localesToDelete) {
+      deleteMutation.mutate({ context, locales: localesToDelete });
+    }
     setOpen(false);
   };
 
-  const { languageTool: shortcut } = useKnownHotkeys();
-  useHotkeys(shortcut.hotkey, () => onOpenChange(true), { scopes: ['global'], keyup: true, enabled: !open });
+  const hotkeys = useKnownHotkeys();
+  useHotkeys(hotkeys.languageTool.hotkey, () => onOpenChange(true), { scopes: ['global'], keyup: true, enabled: !open });
+  const deleteRef = useHotkeys(hotkeys.deleteLanguage.hotkey, () => deleteSelectedLanguage(), { scopes: ['global'] });
   const enter = useHotkeys(['Enter'], () => save(), { scopes: ['global'], enabled: open, enableOnFormTags: true });
 
   return (
@@ -65,20 +127,53 @@ export const LanguageTool = () => {
         <Tooltip>
           <TooltipTrigger asChild>
             <DialogTrigger asChild>
-              <Button icon={IvyIcons.WsStart} aria-label={shortcut.label} />
+              <Button icon={IvyIcons.WsStart} aria-label={hotkeys.languageTool.label} />
             </DialogTrigger>
           </TooltipTrigger>
-          <TooltipContent>{shortcut.label}</TooltipContent>
+          <TooltipContent>{hotkeys.languageTool.label}</TooltipContent>
         </Tooltip>
       </TooltipProvider>
-      <DialogContent>
+      <DialogContent ref={deleteRef} onClick={() => table.resetRowSelection()}>
         <DialogHeader>
           <DialogTitle>{t('dialog.languageTool.title')}</DialogTitle>
         </DialogHeader>
         <DialogDescription>{t('dialog.languageTool.description')}</DialogDescription>
-        <Flex direction='column' gap={3} ref={enter} tabIndex={-1}>
+        <Flex direction='column' gap={3} ref={enter}>
           <BasicField label={t('dialog.languageTool.label.defaultLanguage')}>
-            <BasicSelect value={defaultLanguage} onValueChange={setDefaultLanguage} items={languageItems} />
+            <BasicSelect value={defaultLanguage} onValueChange={setDefaultLanguage} items={languages} />
+          </BasicField>
+          <BasicField
+            label={t('common.label.languages')}
+            control={
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      icon={IvyIcons.Trash}
+                      onClick={event => {
+                        deleteSelectedLanguage();
+                        event.stopPropagation();
+                      }}
+                      disabled={table.getSelectedRowModel().flatRows.length === 0}
+                      aria-label={hotkeys.deleteLanguage.label}
+                    />
+                  </TooltipTrigger>
+                  <TooltipContent>{hotkeys.deleteLanguage.label}</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            }
+          >
+            <Table onKeyDown={handleKeyDown} onClick={event => event.stopPropagation()}>
+              <TableBody>
+                {table.getRowModel().rows.map(row => (
+                  <SelectRow key={row.id} row={row}>
+                    {row.getVisibleCells().map(cell => (
+                      <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+                    ))}
+                  </SelectRow>
+                ))}
+              </TableBody>
+            </Table>
           </BasicField>
         </Flex>
         <DialogFooter>
@@ -89,4 +184,9 @@ export const LanguageTool = () => {
       </DialogContent>
     </Dialog>
   );
+};
+
+type Language = {
+  value: string;
+  label: string;
 };

--- a/packages/cms-editor/src/translation/cms-editor/de.json
+++ b/packages/cms-editor/src/translation/cms-editor/de.json
@@ -8,6 +8,7 @@
     },
     "label": {
       "details": "Details",
+      "languages": "Sprachen",
       "name": "Name",
       "namespace": "Namensbereich",
       "save": "Speichern",
@@ -33,6 +34,7 @@
   "hotkey": {
     "addContentObject": "Inhaltsobjekt hinzufügen ({{hotkey}})",
     "deleteContentObject": "Inhaltsobjekt löschen ({{hotkey}})",
+    "deleteLanguage": "Sprache löschen ({{hotkey}})",
     "languageTool": "Sprachwerkzeug ({{hotkey}})"
   },
   "label": {

--- a/packages/cms-editor/src/translation/cms-editor/en.json
+++ b/packages/cms-editor/src/translation/cms-editor/en.json
@@ -8,6 +8,7 @@
     },
     "label": {
       "details": "Details",
+      "languages": "Languages",
       "name": "Name",
       "namespace": "Namespace",
       "save": "Save",
@@ -33,6 +34,7 @@
   "hotkey": {
     "addContentObject": "Add Content Object ({{hotkey}})",
     "deleteContentObject": "Delete Content Object ({{hotkey}})",
+    "deleteLanguage": "Delete Language ({{hotkey}})",
     "languageTool": "Language Tool ({{hotkey}})"
   },
   "label": {

--- a/packages/cms-editor/src/utils/hotkeys.ts
+++ b/packages/cms-editor/src/utils/hotkeys.ts
@@ -16,6 +16,11 @@ export const useKnownHotkeys = () => {
     return { hotkey, label: t('hotkey.languageTool', { hotkey: hotkeyText(hotkey) }) };
   }, [t]);
 
+  const deleteLanguage = useMemo<KnownHotkey>(() => {
+    const hotkey = 'Delete';
+    return { hotkey, label: t('hotkey.deleteLanguage', { hotkey: hotkeyText(hotkey) }) };
+  }, [t]);
+
   const addContentObject = useMemo<KnownHotkey>(() => {
     const hotkey = 'A';
     return { hotkey, label: t('hotkey.addContentObject', { hotkey: hotkeyText(hotkey) }) };
@@ -41,5 +46,5 @@ export const useKnownHotkeys = () => {
     return { hotkey, label: t('common.hotkey.focusInscription', { hotkey: hotkeyText(hotkey) }) };
   }, [t]);
 
-  return { openHelp, languageTool, addContentObject, deleteContentObject, focusToolbar, focusMain, focusInscription };
+  return { openHelp, languageTool, deleteLanguage, addContentObject, deleteContentObject, focusToolbar, focusMain, focusInscription };
 };

--- a/packages/protocol/src/editor.ts
+++ b/packages/protocol/src/editor.ts
@@ -10,6 +10,8 @@ export type ContentObjectType = ("STRING" | "FILE" | "FOLDER")
 
 export interface CMS {
   cmsActionArgs: CmsActionArgs;
+  cmsAddLocalesArgs: CmsAddLocalesArgs;
+  cmsCountLocaleValueArgs: CmsCountLocaleValueArgs;
   cmsCreateArgs: CmsCreateArgs;
   cmsData: CmsData;
   cmsDataArgs: CmsDataArgs;
@@ -18,7 +20,9 @@ export interface CMS {
   cmsDeleteValueArgs: CmsDeleteValueArgs;
   cmsEditorDataContext: CmsEditorDataContext;
   cmsReadArgs: CmsReadArgs;
+  cmsRemoveLocalesArgs: CmsRemoveLocalesArgs;
   cmsUpdateValueArgs: CmsUpdateValueArgs;
+  long: number;
   string: string[];
   void: Void;
   [k: string]: unknown;
@@ -32,6 +36,14 @@ export interface CmsEditorDataContext {
   app: string;
   file: string;
   pmv: string;
+}
+export interface CmsAddLocalesArgs {
+  context: CmsEditorDataContext;
+  locales: string[];
+}
+export interface CmsCountLocaleValueArgs {
+  context: CmsEditorDataContext;
+  locale: string;
 }
 export interface CmsCreateArgs {
   contentObject: CmsDataObject;
@@ -69,6 +81,10 @@ export interface CmsDeleteValueObject {
 export interface CmsReadArgs {
   context: CmsEditorDataContext;
   uri: string;
+}
+export interface CmsRemoveLocalesArgs {
+  context: CmsEditorDataContext;
+  locales: string[];
 }
 export interface CmsUpdateValueArgs {
   context: CmsEditorDataContext;

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -8,6 +8,7 @@ import type {
   CmsDeleteValueArgs,
   CmsEditorDataContext,
   CmsReadArgs,
+  CmsRemoveLocalesArgs,
   CmsUpdateValueArgs,
   Void
 } from './editor';
@@ -34,6 +35,7 @@ export interface ClientContext {
 export interface MetaRequestTypes {
   'meta/supportedLocales': [null, Array<string>];
   'meta/locales': [CmsEditorDataContext, Array<string>];
+  'meta/removeLocales': [CmsRemoveLocalesArgs, Void];
 }
 
 export interface RequestTypes extends MetaRequestTypes {

--- a/playwright/tests/pageobjects/main/LanguageTool.ts
+++ b/playwright/tests/pageobjects/main/LanguageTool.ts
@@ -1,16 +1,21 @@
 import type { Locator, Page } from '@playwright/test';
 import { Select } from '../abstract/Select';
+import { Table } from './Table';
 
 export class LanguageTool {
   readonly locator: Locator;
   readonly trigger: Locator;
   readonly defaultLanguage: Select;
+  readonly deleteLanguage: Locator;
+  readonly languages: Table;
   readonly save: Locator;
 
   constructor(page: Page, parent: Locator) {
     this.locator = page.getByRole('dialog');
     this.trigger = parent.getByRole('button', { name: 'Language Tool' });
     this.defaultLanguage = new Select(page, this.locator, { name: 'Default Language' });
+    this.deleteLanguage = this.locator.getByRole('button', { name: 'Delete Language' });
+    this.languages = new Table(this.locator);
     this.save = this.locator.getByRole('button', { name: 'Save' });
   }
 }

--- a/playwright/tests/pageobjects/main/Table.ts
+++ b/playwright/tests/pageobjects/main/Table.ts
@@ -24,6 +24,13 @@ export class Table {
       await this.row(i).expectToBeUnselected();
     }
   }
+
+  async expectToHaveRows(...rows: Array<Array<string>>) {
+    for (let i = 0; i < rows.length; i++) {
+      const row = this.row(i);
+      await row.expectToHaveValues(...rows[i]);
+    }
+  }
 }
 
 export class Header {


### PR DESCRIPTION
- Show a table with the languages present in the CMS in the language tool:
  - Selectable rows
  - Keyboard navigation
- The selected language can be deleted in the dialog by clicking the "Delete" button.
- Languages are truly deleted when the dialog is closed using the "Save" button.
