### PR TITLE
XIVY-16943 fix: auto select new content object

### DIFF
--- a/packages/cms-editor/src/main/MainContent.tsx
+++ b/packages/cms-editor/src/main/MainContent.tsx
@@ -47,7 +47,9 @@ export const MainContent = () => {
     onSelect: selectedRows => {
       const selectedRowId = Object.keys(selectedRows).find(key => selectedRows[key]);
       const selectedContentObject = table.getRowModel().flatRows.find(row => row.id === selectedRowId)?.index;
-      setSelectedContentObject(selectedContentObject);
+      if (selectedContentObject !== undefined) {
+        setSelectedContentObject(selectedContentObject);
+      }
     }
   });
 

--- a/playwright/tests/integration/mock/add.spec.ts
+++ b/playwright/tests/integration/mock/add.spec.ts
@@ -12,6 +12,12 @@ test('add', async () => {
   await editor.main.table.row(0).expectToBeSelected();
   await editor.main.table.row(0).expectToHaveColumns(['/A/TestNamespace/TestContentObject'], ['TestValue']);
   await editor.detail.expectToHaveValues('/A/TestNamespace/TestContentObject', { English: 'TestValue', German: '' });
+
+  await editor.main.control.add.add('TestContentObject', '/Z/TestNamespace', { English: 'TestValue' });
+  await editor.main.table.locator.locator('../..').evaluate((el: HTMLElement) => (el.scrollTop = el.scrollHeight));
+  await editor.main.table.row(-1).expectToBeSelected();
+  await editor.main.table.row(-1).expectToHaveColumns(['/Z/TestNamespace/TestContentObject'], ['TestValue']);
+  await editor.detail.expectToHaveValues('/Z/TestNamespace/TestContentObject', { English: 'TestValue', German: '' });
 });
 
 test('disable if no languages are present in the CMS', async () => {


### PR DESCRIPTION
If the newly added Content Object was the last element in the table, it was not selected automatically after adding it.