### PR TITLE
XIVY-17244 base64 encode file values

### DIFF
--- a/integrations/standalone/src/mock/cms-client-mock.ts
+++ b/integrations/standalone/src/mock/cms-client-mock.ts
@@ -19,8 +19,6 @@ import type {
   CmsDeleteValueArgs,
   CmsReadArgs,
   CmsRemoveLocalesArgs,
-  CmsUpdateFileValueArgs,
-  CmsUpdateStringValueArgs,
   CmsUpdateValueArgs,
   MetaRequestTypes,
   Void
@@ -76,12 +74,12 @@ export class CmsClientMock implements Client {
     return Promise.resolve(co ?? ({} as CmsDataObject));
   }
 
-  updateStringValue = (args: CmsUpdateStringValueArgs): Promise<Void> => {
+  updateStringValue = (args: CmsUpdateValueArgs): Promise<Void> => {
     this.updateValue(args, isCmsStringDataObject);
     return Promise.resolve({});
   };
 
-  updateFileValue = (args: CmsUpdateFileValueArgs): Promise<Void> => {
+  updateFileValue = (args: CmsUpdateValueArgs): Promise<Void> => {
     this.updateValue(args, isCmsFileDataObject);
     return Promise.resolve({});
   };

--- a/packages/cms-editor/src/components/FileValueField.test.tsx
+++ b/packages/cms-editor/src/components/FileValueField.test.tsx
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { customRender } from '../context/test-utils/test-utils';
 import type { Language } from '../main/control/language-tool/language-utils';
-import { FileValueField, type FileValueFieldProps } from './FileValueField';
+import { fileValue, FileValueField, type FileValueFieldProps } from './FileValueField';
 
 test('open file button', () => {
   const contentObject = { type: 'FILE', uri: '/ContentObject', values: { en: 'url' } } as unknown as CmsReadFileDataObject;
@@ -46,6 +46,11 @@ describe('file pcker', () => {
     expect(screen.getByText('TestFile.txt')).toBeInTheDocument();
     expect(screen.getByRole('link')).toHaveTextContent('Change File');
   });
+});
+
+test('fileValue', async () => {
+  const file = new File(['test'], 'test.txt', { type: 'text/plain' });
+  expect(await fileValue(file)).toEqual('dGVzdA==');
 });
 
 const renderFileValueField = (props?: Partial<FileValueFieldProps>) => {

--- a/packages/cms-editor/src/components/FileValueField.tsx
+++ b/packages/cms-editor/src/components/FileValueField.tsx
@@ -19,7 +19,7 @@ import { BaseValueField, type BaseValueFieldProps } from './BaseValueField';
 import './FileValueField.css';
 
 export type FileValueFieldProps = BaseValueFieldProps<CmsFileDataObject | CmsReadFileDataObject> & {
-  updateValue: (languageTag: string, value: Array<number>) => void;
+  updateValue: (languageTag: string, value: string) => void;
   deleteValue: (languageTag: string) => void;
   setFileExtension?: (fileExtension?: string) => void;
   allowOpenFile?: boolean;
@@ -57,7 +57,7 @@ export const FileValueField = ({ updateValue, deleteValue, setFileExtension, all
     if (!file) {
       return;
     }
-    updateValue(baseProps.language.value, Array.from(new Uint8Array(await file.arrayBuffer())));
+    updateValue(baseProps.language.value, await fileValue(file));
     setFileNameValue(file.name);
     setFileExtension?.(file.name.includes('.') ? file.name.slice(file.name.lastIndexOf('.') + 1) : '');
   };
@@ -124,4 +124,16 @@ export const FileValueField = ({ updateValue, deleteValue, setFileExtension, all
       </Flex>
     </BaseValueField>
   );
+};
+
+export const fileValue = (file: File): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      resolve(result.slice(result.indexOf(',') + 1));
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
 };

--- a/packages/cms-editor/src/detail/DetailContent.tsx
+++ b/packages/cms-editor/src/detail/DetailContent.tsx
@@ -5,8 +5,7 @@ import type {
   CmsDataObjectValues,
   CmsDeleteValueArgs,
   CmsStringDataObject,
-  CmsUpdateFileValueArgs,
-  CmsUpdateStringValueArgs,
+  CmsUpdateValueArgs,
   MapStringBoolean,
   MapStringString
 } from '@axonivy/cms-editor-protocol';
@@ -65,7 +64,7 @@ export const DetailContent = () => {
   );
 
   const updateStringValueMutation = useMutation({
-    mutationFn: async (args: CmsUpdateStringValueArgs) => {
+    mutationFn: async (args: CmsUpdateValueArgs) => {
       const changeValueUpdater = (values: MapStringString) => ({ ...values, [args.updateObject.languageTag]: args.updateObject.value });
       updateValuesInReadQuery<CmsStringDataObject>(args.updateObject.uri, changeValueUpdater);
       if (defaultLanguageTags.includes(args.updateObject.languageTag)) {
@@ -76,7 +75,7 @@ export const DetailContent = () => {
   });
 
   const updateFileValueMutation = useMutation({
-    mutationFn: async (args: CmsUpdateFileValueArgs) => {
+    mutationFn: async (args: CmsUpdateValueArgs) => {
       if (defaultLanguageTags.includes(args.updateObject.languageTag)) {
         const changeValueUpdater = (values: MapStringBoolean) => ({ ...values, [args.updateObject.languageTag]: true });
         updateValuesInDataQuery<CmsDataFileDataObject>(args.updateObject.uri, changeValueUpdater);
@@ -145,7 +144,7 @@ export const DetailContent = () => {
             <FileValueField
               key={language.value}
               contentObject={contentObject}
-              updateValue={(languageTag: string, value: Array<number>) =>
+              updateValue={(languageTag: string, value: string) =>
                 updateFileValueMutation.mutate({ context, updateObject: { uri, languageTag, value } })
               }
               allowOpenFile

--- a/packages/cms-editor/src/main/control/AddContentObject.tsx
+++ b/packages/cms-editor/src/main/control/AddContentObject.tsx
@@ -6,7 +6,6 @@ import {
   type CmsFileDataObject,
   type CmsStringDataObject,
   type ContentObjectType,
-  type MapStringByte,
   type MapStringString
 } from '@axonivy/cms-editor-protocol';
 import {
@@ -108,7 +107,7 @@ export const AddContentObjectContent = ({
   const [namespace, setNamespace] = useState(initialNamespace(contentObjects, selectedContentObject));
   const [type, setType] = useState<ContentObjectType>('STRING');
   const [fileExtension, setFileExtension] = useState<string | undefined>();
-  const [values, setValues] = useState<MapStringString | MapStringByte>(() => allValuesEmpty());
+  const [values, setValues] = useState<MapStringString>(() => allValuesEmpty());
 
   const changeType = (type: ContentObjectType) => {
     if (type === 'FILE') {
@@ -213,6 +212,7 @@ export const AddContentObjectContent = ({
       )}
       {toLanguages(languageTags, languageDisplayName).map((language: Language) => {
         const props = {
+          updateValue: (languageTag: string, value: string) => setValues(values => ({ ...values, [languageTag]: value })),
           deleteValue: (languageTag: string) => setValues(values => removeValue(values, languageTag)),
           language,
           disabled: isPending,
@@ -220,24 +220,9 @@ export const AddContentObjectContent = ({
         };
         const contentObject = { uri: `${namespace}/${name}`, type, values, fileExtension } as CmsStringDataObject | CmsFileDataObject;
         return isCmsFileDataObject(contentObject) ? (
-          <FileValueField
-            key={language.value}
-            contentObject={contentObject}
-            updateValue={(languageTag: string, value: Array<number>) =>
-              setValues(values => ({ ...values, [languageTag]: value }) as MapStringByte)
-            }
-            setFileExtension={setFileExtension}
-            {...props}
-          />
+          <FileValueField key={language.value} contentObject={contentObject} setFileExtension={setFileExtension} {...props} />
         ) : (
-          <StringValueField
-            key={language.value}
-            contentObject={contentObject}
-            updateValue={(languageTag: string, value: string) =>
-              setValues(values => ({ ...values, [languageTag]: value }) as MapStringString)
-            }
-            {...props}
-          />
+          <StringValueField key={language.value} contentObject={contentObject} {...props} />
         );
       })}
       {isError && <Message variant='error' message={t('message.error', { error })} className='cms-editor-add-dialog-error-message' />}

--- a/packages/cms-editor/src/protocol/client-json-rpc.ts
+++ b/packages/cms-editor/src/protocol/client-json-rpc.ts
@@ -11,8 +11,7 @@ import type {
   CmsDeleteValueArgs,
   CmsReadArgs,
   CmsRemoveLocalesArgs,
-  CmsUpdateFileValueArgs,
-  CmsUpdateStringValueArgs,
+  CmsUpdateValueArgs,
   MetaRequestTypes,
   NotificationTypes,
   RequestTypes,
@@ -37,11 +36,11 @@ export class ClientJsonRpc extends BaseRpcClient implements Client {
     return this.sendRequest('read', args);
   }
 
-  updateStringValue = (args: CmsUpdateStringValueArgs): Promise<Void> => {
+  updateStringValue = (args: CmsUpdateValueArgs): Promise<Void> => {
     return this.sendRequest('updateStringValue', args);
   };
 
-  updateFileValue = (args: CmsUpdateFileValueArgs): Promise<Void> => {
+  updateFileValue = (args: CmsUpdateValueArgs): Promise<Void> => {
     return this.sendRequest('updateFileValue', args);
   };
 

--- a/packages/cms-editor/src/utils/cms-utils.test.ts
+++ b/packages/cms-editor/src/utils/cms-utils.test.ts
@@ -23,7 +23,7 @@ test('CmsDataObject type guards', () => {
   const file = { type: 'FILE' } as CmsDataObject;
   const fileData = {
     type: 'FILE',
-    values: { en: Array.from('value').map(c => c.charCodeAt(0)), de: Array.from('wert').map(c => c.charCodeAt(0)) }
+    values: { en: 'dGVzdA==', de: 'dGVzdA==' }
   } as unknown as CmsDataObject;
   const dataFileData = { type: 'FILE', values: { en: true, de: false } } as unknown as CmsDataObject;
   const readFileData = {
@@ -45,7 +45,7 @@ test('CmsDataObject type guards', () => {
   expect(isCmsFileDataObject(file)).toBeTruthy();
   expect(isCmsFileDataObject(fileData)).toBeTruthy();
   expect(isCmsFileDataObject(dataFileData)).toBeFalsy();
-  expect(isCmsFileDataObject(readFileData)).toBeFalsy();
+  expect(isCmsFileDataObject(readFileData)).toBeTruthy();
 
   expect(isCmsDataFileDataObject(undefined)).toBeFalsy();
   expect(isCmsDataFileDataObject(folder)).toBeFalsy();
@@ -59,7 +59,7 @@ test('CmsDataObject type guards', () => {
   expect(isCmsReadFileDataObject(folder)).toBeFalsy();
   expect(isCmsReadFileDataObject(string)).toBeFalsy();
   expect(isCmsReadFileDataObject(file)).toBeTruthy();
-  expect(isCmsReadFileDataObject(fileData)).toBeFalsy();
+  expect(isCmsReadFileDataObject(fileData)).toBeTruthy();
   expect(isCmsReadFileDataObject(dataFileData)).toBeFalsy();
   expect(isCmsReadFileDataObject(readFileData)).toBeTruthy();
 

--- a/packages/cms-editor/src/utils/cms-utils.ts
+++ b/packages/cms-editor/src/utils/cms-utils.ts
@@ -18,8 +18,7 @@ export const isCmsStringDataObject = (object?: CmsDataObject): object is CmsStri
 const isAnyCmsFileDataObject = (object?: CmsDataObject): object is CmsFileDataObject | CmsDataFileDataObject | CmsReadFileDataObject =>
   object?.type === 'FILE';
 export const isCmsFileDataObject = (object?: CmsDataObject): object is CmsFileDataObject =>
-  isAnyCmsFileDataObject(object) &&
-  (!object.values || Object.values(object.values).every(value => Array.isArray(value) && value.every(num => typeof num === 'number')));
+  isAnyCmsFileDataObject(object) && (!object.values || Object.values(object.values).every(value => typeof value === 'string'));
 export const isCmsDataFileDataObject = (object?: CmsDataObject): object is CmsDataFileDataObject =>
   isAnyCmsFileDataObject(object) && (!object.values || Object.values(object.values).every(value => typeof value === 'boolean'));
 export const isCmsReadFileDataObject = (object?: CmsDataObject): object is CmsReadFileDataObject =>

--- a/packages/protocol/src/editor.ts
+++ b/packages/protocol/src/editor.ts
@@ -7,12 +7,12 @@
  */
 
 export type ContentObjectType = ("STRING" | "FILE" | "FOLDER")
-export type CmsDataObject =
-  | CmsFolderDataObject
+export type CmsValueDataObject =
   | CmsStringDataObject
   | CmsFileDataObject
   | CmsDataFileDataObject
   | CmsReadFileDataObject;
+export type CmsDataObject = CmsFolderDataObject | CmsValueDataObject;
 
 export interface CMS {
   cmsActionArgs: CmsActionArgs;
@@ -28,8 +28,7 @@ export interface CMS {
   cmsEditorDataContext: CmsEditorDataContext;
   cmsReadArgs: CmsReadArgs;
   cmsRemoveLocalesArgs: CmsRemoveLocalesArgs;
-  cmsUpdateFileValueArgs: CmsUpdateFileValueArgs;
-  cmsUpdateStringValueArgs: CmsUpdateStringValueArgs;
+  cmsUpdateValueArgs: CmsUpdateValueArgs;
   long: MapStringLong;
   string: string[];
   void: Void;
@@ -61,10 +60,10 @@ export interface CmsFileDataObject {
   fileExtension: string;
   type: ContentObjectType;
   uri: string;
-  values: MapStringByte;
+  values: MapStringString;
 }
-export interface MapStringByte {
-  [k: string]: Array<number>;
+export interface MapStringString {
+  [k: string]: string;
 }
 export interface CmsCreateStringArgs {
   contentObject: CmsStringDataObject;
@@ -75,18 +74,9 @@ export interface CmsStringDataObject {
   uri: string;
   values: MapStringString;
 }
-export interface MapStringString {
-  [k: string]: string;
-}
 export interface CmsData {
   context: CmsEditorDataContext;
-  data: (
-    | CmsFolderDataObject
-    | CmsStringDataObject
-    | CmsFileDataObject
-    | CmsDataFileDataObject
-    | CmsReadFileDataObject
-  )[];
+  data: (CmsFolderDataObject | CmsValueDataObject)[];
   helpUrl: string;
 }
 export interface CmsFolderDataObject {
@@ -137,20 +127,11 @@ export interface CmsRemoveLocalesArgs {
   context: CmsEditorDataContext;
   locales: string[];
 }
-export interface CmsUpdateFileValueArgs {
+export interface CmsUpdateValueArgs {
   context: CmsEditorDataContext;
-  updateObject: CmsUpdateFileValueObject;
+  updateObject: CmsUpdateValueObject;
 }
-export interface CmsUpdateFileValueObject {
-  languageTag: string;
-  uri: string;
-  value: Array<number>;
-}
-export interface CmsUpdateStringValueArgs {
-  context: CmsEditorDataContext;
-  updateObject: CmsUpdateStringValueObject;
-}
-export interface CmsUpdateStringValueObject {
+export interface CmsUpdateValueObject {
   languageTag: string;
   uri: string;
   value: string;

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -12,10 +12,8 @@ import type {
   CmsEditorDataContext,
   CmsReadArgs,
   CmsRemoveLocalesArgs,
-  CmsUpdateFileValueArgs,
-  CmsUpdateStringValueArgs,
+  CmsUpdateValueArgs,
   MapStringBoolean,
-  MapStringByte,
   MapStringLong,
   MapStringString,
   MapStringURI,
@@ -24,17 +22,16 @@ import type {
 
 export type EditorProps = { context: CmsEditorDataContext };
 
-export type CmsDataObjectValues = MapStringString | MapStringByte | MapStringBoolean | MapStringURI;
+export type CmsDataObjectValues = MapStringString | MapStringBoolean | MapStringURI;
 export type CmsCreateObjectArgs = CmsCreateStringArgs | CmsCreateFileArgs;
-export type CmsUpdateValueArgs = CmsUpdateStringValueArgs | CmsUpdateFileValueArgs;
 
 export interface Client {
   data(args: CmsDataArgs): Promise<CmsData>;
   createString(args: CmsCreateStringArgs): Promise<Void>;
   createFile(args: CmsCreateFileArgs): Promise<Void>;
   read(args: CmsReadArgs): Promise<CmsDataObject>;
-  updateStringValue(args: CmsUpdateStringValueArgs): Promise<Void>;
-  updateFileValue(args: CmsUpdateFileValueArgs): Promise<Void>;
+  updateStringValue(args: CmsUpdateValueArgs): Promise<Void>;
+  updateFileValue(args: CmsUpdateValueArgs): Promise<Void>;
   deleteValue(args: CmsDeleteValueArgs): Promise<Void>;
   delete(args: CmsDeleteArgs): Promise<Void>;
   addLocales(args: CmsAddLocalesArgs): Promise<Void>;
@@ -58,8 +55,8 @@ export interface RequestTypes extends MetaRequestTypes {
   createString: [CmsCreateStringArgs, Void];
   createFile: [CmsCreateFileArgs, Void];
   read: [CmsReadArgs, CmsDataObject];
-  updateStringValue: [CmsUpdateStringValueArgs, Void];
-  updateFileValue: [CmsUpdateFileValueArgs, Void];
+  updateStringValue: [CmsUpdateValueArgs, Void];
+  updateFileValue: [CmsUpdateValueArgs, Void];
   deleteValue: [CmsDeleteValueArgs, Void];
   delete: [CmsDeleteArgs, Void];
   addLocales: [CmsAddLocalesArgs, Void];


### PR DESCRIPTION
Instead of using byte arrays to represent file values, which have a 250% overhead when sent using JSON, use base64 encoded strings with only a 33% overhead.